### PR TITLE
레이아웃 사용 예제 페이지 경로 추가

### DIFF
--- a/src/app/examples/custom-layout/page.tsx
+++ b/src/app/examples/custom-layout/page.tsx
@@ -1,0 +1,126 @@
+import { CustomLayout } from '@/components/layout';
+import { Settings, Users, BarChart3, Package, ShoppingCart, FileText } from 'lucide-react';
+
+export default function CustomLayoutExample() {
+  return (
+    <CustomLayout
+      showTopBar={false}
+      showSearchBar={false}
+      showMainNav={false}
+      showFooter={false}
+      showBottomNav={false}
+    >
+      <div className="flex h-full">
+        {/* 사이드바 */}
+        <aside className="desktop:block bg-bg-200 hidden w-64 p-6">
+          <div className="mb-8">
+            <h2 className="text-text-100 mb-4 text-lg font-bold">관리자 대시보드</h2>
+          </div>
+
+          <nav className="space-y-2">
+            {[
+              { icon: BarChart3, label: '대시보드' },
+              { icon: Package, label: '상품 관리' },
+              { icon: ShoppingCart, label: '주문 관리' },
+              { icon: Users, label: '회원 관리' },
+              { icon: FileText, label: '게시판 관리' },
+              { icon: Settings, label: '설정' },
+            ].map((item) => {
+              const Icon = item.icon;
+              return (
+                <button
+                  key={item.label}
+                  className="text-text-200 hover:text-primary-300 hover:bg-bg-300 flex w-full items-center space-x-3 rounded-lg px-4 py-3 text-left transition-colors"
+                >
+                  <Icon className="h-5 w-5" />
+                  <span className="font-medium">{item.label}</span>
+                </button>
+              );
+            })}
+          </nav>
+        </aside>
+
+        {/* 메인 콘텐츠 */}
+        <main className="flex-1 p-8">
+          <div className="mb-8">
+            <h1 className="text-text-100 mb-2 text-2xl font-bold">CustomLayout 예시</h1>
+            <p className="text-text-200">
+              이 페이지는 사이드바가 있는 완전 커스텀 레이아웃을 사용합니다. 관리자 대시보드에서
+              사용합니다.
+            </p>
+          </div>
+
+          <div className="bg-bg-200 mb-6 rounded-lg p-6">
+            <h2 className="text-text-100 mb-3 text-lg font-semibold">포함된 컴포넌트</h2>
+            <ul className="text-text-200 space-y-2">
+              <li>• TopBar (데스크탑 최상단 메뉴)</li>
+              <li>• MobileHeader (모바일/태블릿 헤더)</li>
+            </ul>
+
+            <h2 className="text-text-100 mb-3 mt-4 text-lg font-semibold">제외된 컴포넌트</h2>
+            <ul className="text-text-200 space-y-2">
+              <li>• SearchBar (데스크탑 검색창)</li>
+              <li>• MainNav (데스크탑 상단 메뉴)</li>
+              <li>• Footer (푸터)</li>
+              <li>• BottomNavigation (모바일/태블릿 하단 네비게이션)</li>
+            </ul>
+          </div>
+
+          {/* 대시보드 콘텐츠 */}
+          <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {[
+              { title: '총 주문', value: '1,234', change: '+12%', color: 'text-primary-300' },
+              { title: '총 매출', value: '₩45,678,900', change: '+8%', color: 'text-green-500' },
+              { title: '신규 회원', value: '567', change: '+15%', color: 'text-blue-500' },
+              { title: '상품 수', value: '890', change: '+5%', color: 'text-purple-500' },
+            ].map((stat) => (
+              <div key={stat.title} className="bg-bg-200 rounded-lg p-6">
+                <h3 className="text-text-200 mb-2 text-sm font-medium">{stat.title}</h3>
+                <p className="text-text-100 mb-1 text-2xl font-bold">{stat.value}</p>
+                <p className={`text-sm font-medium ${stat.color}`}>{stat.change}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <div className="bg-bg-200 rounded-lg p-6">
+              <h3 className="text-text-100 mb-4 text-lg font-semibold">최근 주문</h3>
+              <div className="space-y-3">
+                {[1, 2, 3].map((order) => (
+                  <div
+                    key={order}
+                    className="bg-bg-100 flex items-center justify-between rounded-lg p-3"
+                  >
+                    <div>
+                      <p className="text-text-100 font-medium">주문 #{1000 + order}</p>
+                      <p className="text-text-200 text-sm">2024.01.0{order}</p>
+                    </div>
+                    <span className="text-primary-300 font-medium">₩29,900</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="bg-bg-200 rounded-lg p-6">
+              <h3 className="text-text-100 mb-4 text-lg font-semibold">인기 상품</h3>
+              <div className="space-y-3">
+                {[1, 2, 3].map((product) => (
+                  <div
+                    key={product}
+                    className="bg-bg-100 flex items-center justify-between rounded-lg p-3"
+                  >
+                    <div>
+                      <p className="text-text-100 font-medium">상품 {product}</p>
+                      <p className="text-text-200 text-sm">판매량: {100 + product * 50}</p>
+                    </div>
+                    <span className="text-primary-300 font-medium">₩19,900</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </CustomLayout>
+  );
+}

--- a/src/app/examples/full-layout/page.tsx
+++ b/src/app/examples/full-layout/page.tsx
@@ -1,0 +1,38 @@
+import { FullLayout } from '@/components/layout';
+
+export default function FullLayoutExample() {
+  return (
+    <FullLayout>
+      <div className="container py-8">
+        <h1 className="text-text-100 mb-6 text-2xl font-bold">FullLayout 예시</h1>
+        <p className="text-text-200 mb-4">
+          이 페이지는 메인홈과 같은 완전한 레이아웃을 사용합니다.
+        </p>
+
+        <div className="bg-bg-200 mb-6 rounded-lg p-6">
+          <h2 className="text-text-100 mb-3 text-lg font-semibold">포함된 컴포넌트</h2>
+          <ul className="text-text-200 space-y-2">
+            <li>• TopBar (데스크탑 최상단 메뉴)</li>
+            <li>• SearchBar (데스크탑 검색창 + 로고)</li>
+            <li>• MainNav (데스크탑 상단 메뉴)</li>
+            <li>• MobileHeader (모바일/태블릿 헤더)</li>
+            <li>• Footer (푸터)</li>
+            <li>• BottomNavigation (모바일/태블릿 하단 네비게이션)</li>
+          </ul>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {[1, 2, 3, 4, 5, 6].map((item) => (
+            <div key={item} className="bg-bg-200 rounded-lg p-4">
+              <h3 className="text-text-100 mb-2 font-semibold">상품 카드 {item}</h3>
+              <p className="text-text-200 text-sm">
+                이곳에 상품 정보가 표시됩니다. 메인홈과 같은 레이아웃을 사용하는 페이지의
+                예시입니다.
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </FullLayout>
+  );
+}

--- a/src/app/examples/minimal-layout/page.tsx
+++ b/src/app/examples/minimal-layout/page.tsx
@@ -1,0 +1,61 @@
+import { MinimalLayout } from '@/components/layout';
+
+export default function MinimalLayoutExample() {
+  return (
+    <MinimalLayout>
+      <div className="container py-8">
+        <h1 className="text-text-100 mb-6 text-2xl font-bold">MinimalLayout 예시</h1>
+        <p className="text-text-200 mb-4">
+          이 페이지는 검색창, 상단메뉴, 푸터가 없는 최소한의 레이아웃을 사용합니다.
+        </p>
+
+        <div className="bg-bg-200 mb-6 rounded-lg p-6">
+          <h2 className="text-text-100 mb-3 text-lg font-semibold">포함된 컴포넌트</h2>
+          <ul className="text-text-200 space-y-2">
+            <li>• TopBar (데스크탑 최상단 메뉴)</li>
+            <li>• MobileHeader (모바일/태블릿 헤더)</li>
+            <li>• BottomNavigation (모바일/태블릿 하단 네비게이션)</li>
+          </ul>
+
+          <h2 className="text-text-100 mb-3 mt-4 text-lg font-semibold">제외된 컴포넌트</h2>
+          <ul className="text-text-200 space-y-2">
+            <li>• SearchBar (데스크탑 검색창)</li>
+            <li>• MainNav (데스크탑 상단 메뉴)</li>
+            <li>• Footer (푸터)</li>
+          </ul>
+        </div>
+
+        {/* 상품 상세 페이지 시뮬레이션 */}
+        <div className="bg-bg-200 mb-6 rounded-lg p-6">
+          <div className="flex flex-col gap-8 lg:flex-row">
+            {/* 상품 이미지 */}
+            <div className="lg:w-1/2">
+              <div className="bg-bg-300 flex h-80 items-center justify-center rounded-lg">
+                <span className="text-text-300">상품 이미지</span>
+              </div>
+            </div>
+
+            {/* 상품 정보 */}
+            <div className="lg:w-1/2">
+              <h2 className="text-text-100 mb-4 text-xl font-bold">상품명</h2>
+              <p className="text-text-200 mb-4">
+                이곳에 상품 상세 정보가 표시됩니다. 상품 상세 페이지나 검색 결과 페이지에서 사용하는
+                레이아웃입니다.
+              </p>
+              <div className="space-y-2">
+                <div className="flex justify-between">
+                  <span className="text-text-200">가격:</span>
+                  <span className="text-primary-300 font-semibold">₩29,900</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-text-200">배송비:</span>
+                  <span className="text-text-200">무료</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </MinimalLayout>
+  );
+}

--- a/src/app/examples/no-footer-layout/page.tsx
+++ b/src/app/examples/no-footer-layout/page.tsx
@@ -1,0 +1,98 @@
+import { NoFooterLayout } from '@/components/layout';
+
+export default function NoFooterLayoutExample() {
+  return (
+    <NoFooterLayout>
+      <div className="container py-8">
+        <h1 className="text-text-100 mb-6 text-2xl font-bold">NoFooterLayout 예시</h1>
+        <p className="text-text-200 mb-4">
+          이 페이지는 푸터가 없는 레이아웃을 사용합니다. 결제 페이지나 로그인 페이지에서 사용합니다.
+        </p>
+
+        <div className="bg-bg-200 mb-6 rounded-lg p-6">
+          <h2 className="text-text-100 mb-3 text-lg font-semibold">포함된 컴포넌트</h2>
+          <ul className="text-text-200 space-y-2">
+            <li>• TopBar (데스크탑 최상단 메뉴)</li>
+            <li>• SearchBar (데스크탑 검색창 + 로고)</li>
+            <li>• MainNav (데스크탑 상단 메뉴)</li>
+            <li>• MobileHeader (모바일/태블릿 헤더)</li>
+            <li>• BottomNavigation (모바일/태블릿 하단 네비게이션)</li>
+          </ul>
+
+          <h2 className="text-text-100 mb-3 mt-4 text-lg font-semibold">제외된 컴포넌트</h2>
+          <ul className="text-text-200 space-y-2">
+            <li>• Footer (푸터)</li>
+          </ul>
+        </div>
+
+        {/* 결제 페이지 시뮬레이션 */}
+        <div className="mx-auto max-w-2xl">
+          <div className="bg-bg-200 mb-6 rounded-lg p-6">
+            <h2 className="text-text-100 mb-4 text-xl font-bold">결제 정보</h2>
+
+            <div className="space-y-4">
+              <div>
+                <label className="text-text-200 mb-2 block text-sm font-medium">카드 번호</label>
+                <input
+                  type="text"
+                  placeholder="1234 5678 9012 3456"
+                  className="border-bg-300 bg-bg-100 text-text-100 w-full rounded-lg border p-3"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-text-200 mb-2 block text-sm font-medium">만료일</label>
+                  <input
+                    type="text"
+                    placeholder="MM/YY"
+                    className="border-bg-300 bg-bg-100 text-text-100 w-full rounded-lg border p-3"
+                  />
+                </div>
+                <div>
+                  <label className="text-text-200 mb-2 block text-sm font-medium">CVC</label>
+                  <input
+                    type="text"
+                    placeholder="123"
+                    className="border-bg-300 bg-bg-100 text-text-100 w-full rounded-lg border p-3"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="text-text-200 mb-2 block text-sm font-medium">
+                  카드 소유자명
+                </label>
+                <input
+                  type="text"
+                  placeholder="홍길동"
+                  className="border-bg-300 bg-bg-100 text-text-100 w-full rounded-lg border p-3"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-bg-200 rounded-lg p-6">
+            <h2 className="text-text-100 mb-4 text-xl font-bold">주문 요약</h2>
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-text-200">상품 금액:</span>
+                <span className="text-text-100">₩29,900</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-text-200">배송비:</span>
+                <span className="text-text-100">무료</span>
+              </div>
+              <div className="border-bg-300 mt-2 border-t pt-2">
+                <div className="flex justify-between font-bold">
+                  <span className="text-text-100">총 결제금액:</span>
+                  <span className="text-primary-300">₩29,900</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </NoFooterLayout>
+  );
+}

--- a/src/app/examples/page.tsx
+++ b/src/app/examples/page.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link';
+import { ArrowRight, Layout, Search, CreditCard, Settings } from 'lucide-react';
+
+export default function ExamplesPage() {
+  const layoutExamples = [
+    {
+      title: 'FullLayout',
+      description: '메인홈과 같은 완전한 레이아웃',
+      icon: Layout,
+      href: '/examples/full-layout',
+      features: ['TopBar', 'SearchBar', 'MainNav', 'Footer', 'BottomNavigation'],
+    },
+    {
+      title: 'MinimalLayout',
+      description: '검색창, 상단메뉴, 푸터가 없는 레이아웃',
+      icon: Search,
+      href: '/examples/minimal-layout',
+      features: ['TopBar', 'MobileHeader', 'BottomNavigation'],
+    },
+    {
+      title: 'NoFooterLayout',
+      description: '푸터가 없는 레이아웃',
+      icon: CreditCard,
+      href: '/examples/no-footer-layout',
+      features: ['TopBar', 'SearchBar', 'MainNav', 'MobileHeader', 'BottomNavigation'],
+    },
+    {
+      title: 'CustomLayout',
+      description: '사이드바가 있는 완전 커스텀 레이아웃',
+      icon: Settings,
+      href: '/examples/custom-layout',
+      features: ['TopBar', 'MobileHeader', '사이드바'],
+    },
+  ];
+
+  return (
+    <div className="space-y-8 p-8">
+      <div className="mb-12 text-center">
+        <h1 className="text-text-100 mb-4 text-3xl font-bold">레이아웃 시스템 예시</h1>
+        <p className="text-text-200 mx-auto max-w-3xl">
+          우르르 프론트엔드의 다양한 레이아웃 조합을 확인해보세요. 각 레이아웃은 실제 사용 사례에
+          맞춰 설계되었습니다.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {layoutExamples.map((example) => {
+          const Icon = example.icon;
+          return (
+            <Link
+              key={example.title}
+              href={example.href}
+              className="bg-bg-200 hover:bg-bg-300 group rounded-lg p-6 transition-colors"
+            >
+              <div className="mb-4 flex items-start justify-between">
+                <div className="flex items-center space-x-3">
+                  <div className="bg-primary-100 rounded-lg p-2">
+                    <Icon className="text-primary-300 h-6 w-6" />
+                  </div>
+                  <div>
+                    <h2 className="text-text-100 text-xl font-bold">{example.title}</h2>
+                    <p className="text-text-200 text-sm">{example.description}</p>
+                  </div>
+                </div>
+                <ArrowRight className="text-text-300 group-hover:text-primary-300 h-5 w-5 transition-colors" />
+              </div>
+
+              <div className="space-y-3">
+                <div>
+                  <h3 className="text-text-100 mb-2 text-sm font-semibold">포함된 컴포넌트</h3>
+                  <div className="flex flex-wrap gap-1">
+                    {example.features.map((feature) => (
+                      <span
+                        key={feature}
+                        className="bg-bg-100 text-text-200 rounded-md px-2 py-1 text-xs"
+                      >
+                        {feature}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="bg-bg-200 mt-12 rounded-lg p-6">
+        <h2 className="text-text-100 mb-4 text-lg font-semibold">레이아웃 시스템 특징</h2>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+          <div>
+            <h3 className="text-text-100 mb-2 font-semibold">🎯 유연성</h3>
+            <p className="text-text-200 text-sm">
+              각 페이지에서 필요한 레이아웃만 선택하여 사용할 수 있습니다.
+            </p>
+          </div>
+          <div>
+            <h3 className="text-text-100 mb-2 font-semibold">♻️ 재사용성</h3>
+            <p className="text-text-200 text-sm">
+              컴포넌트를 조합하여 다양한 레이아웃을 쉽게 생성할 수 있습니다.
+            </p>
+          </div>
+          <div>
+            <h3 className="text-text-100 mb-2 font-semibold">🔧 확장성</h3>
+            <p className="text-text-200 text-sm">
+              새로운 레이아웃 요구사항에 쉽게 대응할 수 있습니다.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #7 

## 🚩 Summary
![image](https://github.com/user-attachments/assets/463d343a-dea4-47b8-8ff7-a4c8e855a4d3)

- 레이아웃 시스템 사용 예제 페이지 4개 추가 (FullLayout, MinimalLayout, NoFooterLayout, CustomLayout)
- 각 레이아웃별 실제 사용 사례를 시뮬레이션한 예시 페이지 구현
- 레이아웃 컴포넌트 조합의 시각적 데모 제공으로 개발자 경험 향상

## 🛠️ Technical Concerns

- 각 예시 페이지는 실제 사용 사례에 맞춰 설계 (메인홈, 상품상세, 결제페이지, 관리자대시보드)
- CustomLayout의 사이드바는 관리자 대시보드 스타일로 구현하여 실제 활용 가능한 예시 제공
- 모든 예시 페이지에서 포함/제외된 컴포넌트를 명확히 표시하여 레이아웃 시스템 이해도 증진
- 반응형 디자인을 고려한 예시 콘텐츠 구성

## 🙂 To Reviewer
@songcw8 
- 예시 페이지들의 설명이 레이아웃 시스템 이해에 도움이 되는지 피드백 부탁드립니다

## 📋 To Do
이제 글로벌 세팅은 끝난 것 같습니다. 추후 글로벌 세팅이 더 필요하다 생각되면 글로벌 세팅 관련 이슈를 생성하도록 하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 다양한 레이아웃 예시 페이지가 추가되었습니다.
    - 전체 레이아웃, 커스텀 레이아웃, 미니멀 레이아웃, 푸터 없는 레이아웃 등 여러 레이아웃을 직접 확인할 수 있는 예시 페이지를 제공합니다.
    - 각 예시 페이지에서는 해당 레이아웃의 포함/제외 요소와 샘플 콘텐츠(대시보드, 상품, 결제 폼 등)를 시각적으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->