### PR TITLE
판매자 회원가입 비밀번호 검증 라벨 추가 및 리팩토링

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,6 +65,18 @@ textarea {
 }
 
 /* ──────────────
+   Autocomplete 스타일 제거
+   ────────────── */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 30px var(--bg-100) inset !important;
+  -webkit-text-fill-color: var(--text-100) !important;
+  transition: background-color 5000s ease-in-out 0s;
+}
+
+/* ──────────────
    Custom Checkbox Styles
    ────────────── */
 input[type='checkbox'].custom-checkbox {

--- a/src/app/seller-signup/page.tsx
+++ b/src/app/seller-signup/page.tsx
@@ -229,7 +229,9 @@ export default function SellerSignUpPage() {
                 type="tel"
                 placeholder="010-1234-5678"
                 value={formatPhoneNumber(signupFormData.phone)}
-                onChange={(e) => handleInputChange('phone' as FormFieldType, e.target.value)}
+                onChange={(e) =>
+                  handleInputChange('phone' as FormFieldType, e.target.value.replace(/[^0-9]/g, ''))
+                }
                 className={FORM_STYLES.input.base}
                 maxLength={13}
                 required

--- a/src/app/seller-signup/page.tsx
+++ b/src/app/seller-signup/page.tsx
@@ -3,10 +3,20 @@
 import { CustomLayout } from '@/components/layout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { FormField, PasswordStrengthIndicator } from '@/components/form';
 import { Store, ArrowLeft } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useAuthStore } from '@/store';
+import {
+  checkPasswordLength,
+  checkPasswordHasLetter,
+  checkPasswordHasNumber,
+  checkPasswordHasSpecial,
+} from '@/lib/password-utils';
+import { formatPhoneNumber, formatBusinessNumber } from '@/lib/format-utils';
+import { FORM_STYLES } from '@/constants/form-styles';
+import { useSignupForm } from '@/hooks/useSignupForm';
+import { FormFieldType, AgreementType } from '@/types/form';
 
 export default function SellerSignUpPage() {
   const {
@@ -14,124 +24,12 @@ export default function SellerSignUpPage() {
     agreements,
     brandGuide,
     brandGuideType,
-    setSignupFormData,
-    setAgreements,
-    setBrandGuide,
-  } = useAuthStore();
-
-  const handleInputChange = (field: string, value: string) => {
-    setSignupFormData({ [field]: value });
-    if (field === 'brand') {
-      setBrandGuide('', 'guide');
-    }
-  };
-
-  const handleAgreementChange = (field: string, checked: boolean) => {
-    setAgreements({ [field]: checked });
-  };
-
-  const isFormValid = () => {
-    return (
-      signupFormData.email &&
-      signupFormData.password &&
-      signupFormData.passwordConfirm &&
-      signupFormData.password === signupFormData.passwordConfirm &&
-      signupFormData.brand &&
-      signupFormData.company &&
-      signupFormData.ceo &&
-      signupFormData.businessNumber &&
-      signupFormData.phone &&
-      agreements.terms &&
-      agreements.privacy
-    );
-  };
-
-  // 비밀번호 일치 여부 확인
-  const isPasswordMatch = () => {
-    return (
-      signupFormData.password &&
-      signupFormData.passwordConfirm &&
-      signupFormData.password === signupFormData.passwordConfirm
-    );
-  };
-
-  // 비밀번호 확인 메시지
-  const getPasswordConfirmMessage = () => {
-    if (!signupFormData.passwordConfirm) return '';
-    if (signupFormData.password === signupFormData.passwordConfirm) {
-      return '비밀번호가 일치합니다.';
-    } else {
-      return '비밀번호가 일치하지 않습니다.';
-    }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (isFormValid()) {
-      console.log('회원가입 시도:', signupFormData);
-      // TODO: 실제 회원가입 API 연동 예정
-    }
-  };
-
-  const getLength = (field: keyof typeof signupFormData, max: number) =>
-    `${signupFormData[field]?.length || 0}/${max}자`;
-
-  // 전화번호 자동 하이픈 포맷팅 함수
-  const formatPhoneNumber = (value: string) => {
-    // 숫자만 추출
-    const numbers = value.replace(/[^0-9]/g, '');
-
-    // 길이에 따라 하이픈 추가
-    if (numbers.length <= 3) {
-      return numbers;
-    } else if (numbers.length <= 7) {
-      return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
-    } else {
-      return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7, 11)}`;
-    }
-  };
-
-  // 사업자등록번호 자동 하이픈 포맷팅 함수
-  const formatBusinessNumber = (value: string) => {
-    // 숫자만 추출
-    const numbers = value.replace(/[^0-9]/g, '');
-
-    // 길이에 따라 하이픈 추가 (123-45-67890 형식)
-    if (numbers.length <= 3) {
-      return numbers;
-    } else if (numbers.length <= 5) {
-      return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
-    } else {
-      return `${numbers.slice(0, 3)}-${numbers.slice(3, 5)}-${numbers.slice(5, 10)}`;
-    }
-  };
-
-  // 브랜드명 중복 확인 함수
-  const handleBrandDuplicateCheck = async () => {
-    if (!signupFormData.brand.trim()) {
-      setBrandGuide('브랜드명을 입력해주세요.', 'error');
-      return;
-    }
-
-    try {
-      // TODO: 실제 브랜드명 중복 확인 API 호출
-      // const response = await checkBrandDuplicate(signupFormData.brand);
-      // if (response.isDuplicate) {
-      //   setBrandGuide('이미 사용 중인 브랜드명입니다.', 'error');
-      // } else {
-      //   setBrandGuide('사용 가능한 브랜드명입니다.', 'success');
-      // }
-
-      // 임시 로직 (API 구현 전)
-      setBrandGuide('사용 가능한 브랜드명입니다.', 'success');
-    } catch (error) {
-      console.error('브랜드명 중복 확인 실패:', error);
-      setBrandGuide('중복 확인 중 오류가 발생했습니다.', 'error');
-    }
-  };
-
-  const pinkOutlineBtn =
-    'h-10 px-4 rounded-lg border border-primary-300 bg-bg-100 text-primary-300 text-sm font-medium hover:bg-primary-100 transition';
+    handleInputChange,
+    handleAgreementChange,
+    handleBrandDuplicateCheck,
+    handleSubmit,
+    isFormValid,
+  } = useSignupForm();
 
   return (
     <CustomLayout showTopBar={false} showSearchBar={false} showMainNav={false} showFooter={false}>
@@ -161,217 +59,193 @@ export default function SellerSignUpPage() {
           {/* 회원가입 폼 */}
           <form onSubmit={handleSubmit} className="space-y-5">
             {/* 이메일 */}
-            <div>
-              <label className="mb-2 block text-sm font-medium text-text-100">
-                이메일 <span className="text-primary-300">*</span>
-              </label>
+            <FormField label="이메일" required>
               <Input
                 id="email"
                 type="email"
                 placeholder="이메일을 입력하세요"
                 value={signupFormData.email}
-                onChange={(e) => handleInputChange('email', e.target.value)}
-                className="h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-300 focus:ring-offset-0"
+                onChange={(e) => handleInputChange('email' as FormFieldType, e.target.value)}
+                className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
                 required
               />
-            </div>
+            </FormField>
 
             {/* 비밀번호 */}
-            <div>
-              <label className="mb-2 block text-sm font-medium text-text-100">
-                비밀번호 <span className="text-primary-300">*</span>
-              </label>
+            <FormField
+              label="비밀번호"
+              required
+              helperText="영문, 숫자, 특수문자 포함 8자 이상"
+              characterCount={{ current: signupFormData.password?.length || 0, max: 50 }}
+            >
               <Input
                 id="password"
                 type="password"
                 placeholder="******"
                 value={signupFormData.password}
-                onChange={(e) => handleInputChange('password', e.target.value)}
-                className="h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                onChange={(e) => handleInputChange('password' as FormFieldType, e.target.value)}
+                className={FORM_STYLES.input.base}
                 maxLength={50}
                 required
               />
-              <div className="mt-1 flex justify-end">
-                <span className="text-xs text-text-300">{getLength('password', 50)}</span>
-              </div>
-            </div>
+            </FormField>
+            <PasswordStrengthIndicator
+              password={signupFormData.password}
+              checkPasswordLength={checkPasswordLength}
+              checkPasswordHasLetter={checkPasswordHasLetter}
+              checkPasswordHasNumber={checkPasswordHasNumber}
+              checkPasswordHasSpecial={checkPasswordHasSpecial}
+            />
 
             {/* 비밀번호 확인 */}
-            <div>
-              <label className="mb-2 block text-sm font-medium text-text-100">
-                비밀번호 확인 <span className="text-primary-300">*</span>
-              </label>
+            <FormField
+              label="비밀번호 확인"
+              required
+              helperText={
+                signupFormData.passwordConfirm
+                  ? signupFormData.password === signupFormData.passwordConfirm
+                    ? '비밀번호가 일치합니다.'
+                    : '비밀번호가 일치하지 않습니다.'
+                  : undefined
+              }
+              helperTextType={
+                signupFormData.passwordConfirm
+                  ? signupFormData.password === signupFormData.passwordConfirm
+                    ? 'success'
+                    : 'error'
+                  : 'base'
+              }
+              characterCount={{ current: signupFormData.passwordConfirm?.length || 0, max: 50 }}
+            >
               <Input
                 id="passwordConfirm"
                 type="password"
                 placeholder="비밀번호를 다시 입력하세요"
                 value={signupFormData.passwordConfirm}
-                onChange={(e) => handleInputChange('passwordConfirm', e.target.value)}
-                className="h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                onChange={(e) =>
+                  handleInputChange('passwordConfirm' as FormFieldType, e.target.value)
+                }
+                className={FORM_STYLES.input.base}
                 maxLength={50}
                 required
               />
-              <div className="mt-1 flex items-center justify-between">
-                {signupFormData.passwordConfirm && (
-                  <span
-                    className={`text-xs ${
-                      signupFormData.password === signupFormData.passwordConfirm
-                        ? 'text-primary-300'
-                        : 'text-red-500'
-                    }`}
-                  >
-                    {getPasswordConfirmMessage()}
-                  </span>
-                )}
-                <span className="text-xs text-text-300">{getLength('passwordConfirm', 50)}</span>
-              </div>
-            </div>
+            </FormField>
 
             {/* 브랜드명 */}
-            <div>
-              <div className="mb-2 flex items-center">
-                <label className="mr-2 text-sm font-medium text-text-100">
-                  브랜드명 <span className="text-primary-300">*</span>
-                </label>
-              </div>
+            <FormField
+              label="브랜드명"
+              required
+              helperText={brandGuide || undefined}
+              helperTextType={brandGuideType === 'guide' ? 'base' : brandGuideType}
+              characterCount={{ current: signupFormData.brand?.length || 0, max: 20 }}
+            >
               <div className="flex gap-2">
                 <Input
                   id="brand"
                   type="text"
                   placeholder="브랜드명을 입력해주세요"
                   value={signupFormData.brand}
-                  onChange={(e) => handleInputChange('brand', e.target.value)}
-                  className="h-12 flex-1 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                  onChange={(e) => handleInputChange('brand' as FormFieldType, e.target.value)}
+                  className={FORM_STYLES.input.base + ' flex-1'}
                   maxLength={20}
                   required
                 />
                 <button
                   type="button"
-                  className={pinkOutlineBtn + ' h-12 min-w-[120px] rounded-lg'}
+                  className={FORM_STYLES.button.pinkOutline + ' h-12 min-w-[120px] rounded-lg'}
                   onClick={handleBrandDuplicateCheck}
                 >
                   중복 확인
                 </button>
               </div>
-              <div className="mt-1 flex items-center justify-between">
-                <span
-                  className={
-                    brandGuideType === 'success'
-                      ? 'text-xs text-primary-300'
-                      : 'text-xs text-text-300'
-                  }
-                >
-                  {brandGuide}
-                </span>
-                <span className="text-xs text-text-300">{getLength('brand', 20)}</span>
-              </div>
-            </div>
+            </FormField>
 
-            <div>
-              <div className="mb-2 flex items-center justify-between">
-                <label className="text-sm font-medium text-text-100">
-                  상호명 <span className="text-primary-300">*</span>
-                </label>
-              </div>
+            <FormField
+              label="상호명"
+              required
+              characterCount={{ current: signupFormData.company?.length || 0, max: 20 }}
+            >
               <Input
                 id="company"
                 type="text"
                 placeholder="상호명을 입력해주세요"
                 value={signupFormData.company}
-                onChange={(e) => handleInputChange('company', e.target.value)}
-                className="h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                onChange={(e) => handleInputChange('company' as FormFieldType, e.target.value)}
+                className={FORM_STYLES.input.base}
                 maxLength={20}
                 required
               />
-              <div className="mt-1 flex justify-end">
-                <span className="text-xs text-text-300">{getLength('company', 20)}</span>
-              </div>
-            </div>
+            </FormField>
 
-            <div>
-              <div className="mb-2 flex items-center justify-between">
-                <label className="text-sm font-medium text-text-100">
-                  대표이름 <span className="text-primary-300">*</span>
-                </label>
-              </div>
+            <FormField
+              label="대표이름"
+              required
+              characterCount={{ current: signupFormData.ceo?.length || 0, max: 20 }}
+            >
               <Input
                 id="ceo"
                 type="text"
                 placeholder="대표 이름을 입력해주세요"
                 value={signupFormData.ceo}
-                onChange={(e) => handleInputChange('ceo', e.target.value)}
-                className="h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                onChange={(e) => handleInputChange('ceo' as FormFieldType, e.target.value)}
+                className={FORM_STYLES.input.base}
                 maxLength={20}
                 required
               />
-              <div className="mt-1 flex justify-end">
-                <span className="text-xs text-text-300">{getLength('ceo', 20)}</span>
-              </div>
-            </div>
+            </FormField>
 
-            <div>
-              <div className="mb-2 flex items-center justify-between">
-                <label className="text-sm font-medium text-text-100">
-                  사업자 등록번호 <span className="text-primary-300">*</span>
-                </label>
-              </div>
+            <FormField
+              label="사업자 등록번호"
+              required
+              helperText="하이픈(-)을 제외하고 숫자만 입력해주세요"
+              characterCount={{ current: signupFormData.businessNumber?.length || 0, max: 10 }}
+            >
               <Input
                 id="businessNumber"
                 type="text"
                 placeholder="123-45-67890"
                 value={formatBusinessNumber(signupFormData.businessNumber)}
                 onChange={(e) =>
-                  handleInputChange('businessNumber', e.target.value.replace(/[^0-9]/g, ''))
+                  handleInputChange(
+                    'businessNumber' as FormFieldType,
+                    e.target.value.replace(/[^0-9]/g, ''),
+                  )
                 }
-                className="h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                className={FORM_STYLES.input.base}
                 maxLength={12}
                 required
               />
-              <div className="mt-1 flex items-center justify-between">
-                <span className="text-xs text-text-300">
-                  하이픈(-)을 제외하고 숫자만 입력해주세요
-                </span>
-                <span className="text-xs text-text-300">{getLength('businessNumber', 10)}</span>
-              </div>
-            </div>
+            </FormField>
 
             {/* 전화 번호 */}
-            <div>
-              <div className="mb-2 flex items-center justify-between">
-                <label className="text-sm font-medium text-text-100">
-                  휴대폰 번호 <span className="text-primary-300">*</span>
-                </label>
-              </div>
+            <FormField
+              label="휴대폰 번호"
+              required
+              helperText="하이픈(-)을 제외하고 숫자만 입력해주세요"
+              characterCount={{ current: signupFormData.phone?.length || 0, max: 11 }}
+            >
               <Input
                 id="phone"
                 type="tel"
                 placeholder="010-1234-5678"
                 value={formatPhoneNumber(signupFormData.phone)}
-                onChange={(e) => handleInputChange('phone', e.target.value)}
-                className="h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                onChange={(e) => handleInputChange('phone' as FormFieldType, e.target.value)}
+                className={FORM_STYLES.input.base}
                 maxLength={13}
                 required
               />
-              <div className="mt-1 flex items-center justify-between">
-                <span className="text-xs text-text-300">
-                  하이픈(-)을 제외하고 숫자만 입력해주세요
-                </span>
-                <span className="text-xs text-text-300">{getLength('phone', 11)}</span>
-              </div>
-            </div>
+            </FormField>
 
             {/* 주소 */}
-            <div>
-              <div className="mb-2 flex items-center">
-                <label className="mr-2 text-sm font-medium text-text-100">
-                  주소 <span className="text-primary-300">*</span>
-                </label>
-              </div>
+            <FormField label="주소" required>
               <div className="mb-2 flex gap-2">
-                <div className="flex h-12 min-w-0 flex-1 items-center rounded-lg border border-bg-300 bg-bg-200 px-4 text-base text-text-300">
+                <div className={FORM_STYLES.zipcode.display}>
                   {signupFormData.zipcode || '우편번호'}
                 </div>
-                <button type="button" className={pinkOutlineBtn + ' h-12 min-w-[120px] rounded-lg'}>
+                <button
+                  type="button"
+                  className={FORM_STYLES.button.pinkOutline + ' h-12 min-w-[120px] rounded-lg'}
+                >
                   우편 번호
                 </button>
               </div>
@@ -379,24 +253,26 @@ export default function SellerSignUpPage() {
                 type="text"
                 placeholder="도로명"
                 value={signupFormData.addressRoad}
-                onChange={(e) => handleInputChange('addressRoad', e.target.value)}
-                className="mb-2 h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                onChange={(e) => handleInputChange('addressRoad' as FormFieldType, e.target.value)}
+                className={FORM_STYLES.input.base + ' mb-2'}
               />
               <Input
                 type="text"
                 placeholder="지번"
                 value={signupFormData.addressJibun}
-                onChange={(e) => handleInputChange('addressJibun', e.target.value)}
-                className="mb-2 h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                onChange={(e) => handleInputChange('addressJibun' as FormFieldType, e.target.value)}
+                className={FORM_STYLES.input.base + ' mb-2'}
               />
               <Input
                 type="text"
                 placeholder="상세주소를 입력해주세요"
                 value={signupFormData.addressDetail}
-                onChange={(e) => handleInputChange('addressDetail', e.target.value)}
-                className="h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-base text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300"
+                onChange={(e) =>
+                  handleInputChange('addressDetail' as FormFieldType, e.target.value)
+                }
+                className={FORM_STYLES.input.base}
               />
-            </div>
+            </FormField>
 
             {/* 약관 동의 */}
             <div className="mt-6 space-y-3">
@@ -404,8 +280,8 @@ export default function SellerSignUpPage() {
                 <input
                   type="checkbox"
                   checked={agreements.all}
-                  onChange={(e) => handleAgreementChange('all', e.target.checked)}
-                  className="custom-checkbox mr-3 mt-0.5"
+                  onChange={(e) => handleAgreementChange('all' as AgreementType, e.target.checked)}
+                  className={FORM_STYLES.checkbox.base}
                 />
                 <span className="text-sm font-medium text-text-100">전체 약관에 동의합니다</span>
               </label>
@@ -415,8 +291,10 @@ export default function SellerSignUpPage() {
                   <input
                     type="checkbox"
                     checked={agreements.terms}
-                    onChange={(e) => handleAgreementChange('terms', e.target.checked)}
-                    className="custom-checkbox mr-3 mt-0.5"
+                    onChange={(e) =>
+                      handleAgreementChange('terms' as AgreementType, e.target.checked)
+                    }
+                    className={FORM_STYLES.checkbox.base}
                   />
                   <span className="text-sm text-text-200">
                     <span className="text-primary-300 underline">이용약관</span>에 동의합니다 (필수)
@@ -427,8 +305,10 @@ export default function SellerSignUpPage() {
                   <input
                     type="checkbox"
                     checked={agreements.privacy}
-                    onChange={(e) => handleAgreementChange('privacy', e.target.checked)}
-                    className="custom-checkbox mr-3 mt-0.5"
+                    onChange={(e) =>
+                      handleAgreementChange('privacy' as AgreementType, e.target.checked)
+                    }
+                    className={FORM_STYLES.checkbox.base}
                   />
                   <span className="text-sm text-text-200">
                     <span className="text-primary-300 underline">개인정보처리방침</span>에
@@ -440,8 +320,10 @@ export default function SellerSignUpPage() {
                   <input
                     type="checkbox"
                     checked={agreements.marketing}
-                    onChange={(e) => handleAgreementChange('marketing', e.target.checked)}
-                    className="custom-checkbox mr-3 mt-0.5"
+                    onChange={(e) =>
+                      handleAgreementChange('marketing' as AgreementType, e.target.checked)
+                    }
+                    className={FORM_STYLES.checkbox.base}
                   />
                   <span className="text-sm text-text-200">
                     마케팅 정보 수신에 동의합니다 (선택)
@@ -451,11 +333,7 @@ export default function SellerSignUpPage() {
             </div>
 
             {/* 회원가입 버튼 */}
-            <Button
-              type="submit"
-              disabled={!isFormValid()}
-              className="h-12 w-full rounded-lg border border-primary-300 bg-bg-100 text-primary-300 transition-colors hover:bg-primary-100 disabled:border-bg-300 disabled:text-text-300 disabled:hover:bg-bg-100"
-            >
+            <Button type="submit" disabled={!isFormValid} className={FORM_STYLES.button.submit}>
               <Store className="h-4 w-4" />
               판매자 회원가입
             </Button>

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { FORM_STYLES } from '@/constants/form-styles';
+import { HelperTextType } from '@/types/form';
+
+interface FormFieldProps {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+  helperText?: string;
+  helperTextType?: HelperTextType;
+  characterCount?: { current: number; max: number };
+  className?: string;
+}
+
+export const FormField: React.FC<FormFieldProps> = ({
+  label,
+  required = false,
+  children,
+  helperText,
+  helperTextType = 'base',
+  characterCount,
+  className = '',
+}) => {
+  return (
+    <div className={className}>
+      <label className={FORM_STYLES.label.base}>
+        {label} {required && <span className={FORM_STYLES.label.required}>*</span>}
+      </label>
+      {children}
+      {(helperText || characterCount) && (
+        <div className="mt-1 flex items-center justify-between">
+          <div className="flex-1">
+            {helperText && (
+              <span className={FORM_STYLES.helperText[helperTextType]}>{helperText}</span>
+            )}
+          </div>
+          {characterCount && (
+            <span className={FORM_STYLES.helperText.base}>
+              {characterCount.current}/{characterCount.max}자
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/form/PasswordStrengthIndicator.tsx
+++ b/src/components/form/PasswordStrengthIndicator.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { FORM_STYLES } from '@/constants/form-styles';
+
+interface PasswordStrengthIndicatorProps {
+  password: string;
+  checkPasswordLength: (password: string) => boolean;
+  checkPasswordHasLetter: (password: string) => boolean;
+  checkPasswordHasNumber: (password: string) => boolean;
+  checkPasswordHasSpecial: (password: string) => boolean;
+}
+
+interface PasswordCondition {
+  label: string;
+  check: () => boolean;
+}
+
+export const PasswordStrengthIndicator: React.FC<PasswordStrengthIndicatorProps> = ({
+  password,
+  checkPasswordLength,
+  checkPasswordHasLetter,
+  checkPasswordHasNumber,
+  checkPasswordHasSpecial,
+}) => {
+  if (!password) return null;
+
+  const conditions: PasswordCondition[] = [
+    {
+      label: '8자 이상',
+      check: () => checkPasswordLength(password),
+    },
+    {
+      label: '영문 포함',
+      check: () => checkPasswordHasLetter(password),
+    },
+    {
+      label: '숫자 포함',
+      check: () => checkPasswordHasNumber(password),
+    },
+    {
+      label: '특수문자 포함',
+      check: () => checkPasswordHasSpecial(password),
+    },
+  ];
+
+  return (
+    <div className="mt-2 space-y-1">
+      {conditions.map((condition, index) => {
+        const isMet = condition.check();
+        return (
+          <div
+            key={index}
+            className={`flex items-center text-xs ${isMet ? 'text-primary-300' : 'text-text-300'}`}
+          >
+            <span
+              className={`mr-2 h-1.5 w-1.5 rounded-full ${
+                isMet ? 'bg-primary-300' : 'bg-text-300'
+              }`}
+            ></span>
+            {condition.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,0 +1,2 @@
+export { FormField } from './FormField';
+export { PasswordStrengthIndicator } from './PasswordStrengthIndicator';

--- a/src/constants/form-styles.ts
+++ b/src/constants/form-styles.ts
@@ -1,0 +1,41 @@
+// 폼 관련 공통 스타일 상수
+export const FORM_STYLES = {
+  // 입력 필드 기본 스타일
+  input: {
+    base: 'h-12 rounded-lg border-bg-300 bg-bg-100 px-4 py-3 text-sm text-text-100 placeholder:text-text-300 focus:border-primary-300 focus:ring-2 focus:ring-primary-300',
+    focus:
+      'focus:border-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-300 focus:ring-offset-0',
+  },
+
+  // 라벨 스타일
+  label: {
+    base: 'mb-2 block text-sm font-medium text-text-100',
+    required: 'text-primary-300',
+  },
+
+  // 버튼 스타일
+  button: {
+    pinkOutline:
+      'h-10 px-4 rounded-lg border border-primary-300 bg-bg-100 text-primary-300 text-sm font-medium hover:bg-primary-100 transition',
+    submit:
+      'h-12 w-full rounded-lg border border-primary-300 bg-bg-100 text-primary-300 transition-colors hover:bg-primary-100 disabled:border-bg-300 disabled:text-text-300 disabled:hover:bg-bg-100',
+  },
+
+  // 헬퍼 텍스트 스타일
+  helperText: {
+    base: 'text-xs text-text-300',
+    success: 'text-xs text-primary-300',
+    error: 'text-xs text-red-500',
+  },
+
+  // 우편번호 입력 필드 스타일
+  zipcode: {
+    display:
+      'flex h-12 min-w-0 flex-1 items-center rounded-lg border border-bg-300 bg-bg-200 px-4 text-sm text-text-300',
+  },
+
+  // 체크박스 스타일
+  checkbox: {
+    base: 'custom-checkbox mr-3 mt-0.5',
+  },
+} as const;

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -1,0 +1,106 @@
+import { useCallback } from 'react';
+import { useAuthStore } from '@/store';
+import { isPasswordValid } from '@/lib/password-utils';
+import { FormFieldType, AgreementType, SignupFormData, AgreementData } from '@/types/form';
+
+export const useSignupForm = () => {
+  const {
+    signupFormData,
+    agreements,
+    brandGuide,
+    brandGuideType,
+    setSignupFormData,
+    setAgreements,
+    setBrandGuide,
+  } = useAuthStore();
+
+  // 입력 필드 변경 핸들러
+  const handleInputChange = useCallback(
+    (field: FormFieldType, value: string) => {
+      setSignupFormData({ [field]: value } as Partial<SignupFormData>);
+      if (field === 'brand') {
+        setBrandGuide('', 'guide');
+      }
+    },
+    [setSignupFormData, setBrandGuide],
+  );
+
+  // 약관 동의 변경 핸들러
+  const handleAgreementChange = useCallback(
+    (field: AgreementType, checked: boolean) => {
+      setAgreements({ [field]: checked } as Partial<AgreementData>);
+    },
+    [setAgreements],
+  );
+
+  // 브랜드명 중복 확인 핸들러
+  const handleBrandDuplicateCheck = useCallback(async () => {
+    if (!signupFormData.brand.trim()) {
+      setBrandGuide('브랜드명을 입력해주세요.', 'error');
+      return;
+    }
+
+    try {
+      // TODO: 실제 브랜드명 중복 확인 API 호출
+      // const response = await checkBrandDuplicate(signupFormData.brand);
+      // if (response.isDuplicate) {
+      //   setBrandGuide('이미 사용 중인 브랜드명입니다.', 'error');
+      // } else {
+      //   setBrandGuide('사용 가능한 브랜드명입니다.', 'success');
+      // }
+
+      // 임시 로직 (API 구현 전)
+      setBrandGuide('사용 가능한 브랜드명입니다.', 'success');
+    } catch (error) {
+      console.error('브랜드명 중복 확인 실패:', error);
+      setBrandGuide('중복 확인 중 오류가 발생했습니다.', 'error');
+    }
+  }, [signupFormData.brand, setBrandGuide]);
+
+  // 폼 유효성 검사
+  const isFormValid = useCallback(() => {
+    return (
+      signupFormData.email &&
+      signupFormData.password &&
+      signupFormData.passwordConfirm &&
+      signupFormData.password === signupFormData.passwordConfirm &&
+      isPasswordValid(signupFormData.password) &&
+      signupFormData.brand &&
+      signupFormData.company &&
+      signupFormData.ceo &&
+      signupFormData.businessNumber &&
+      signupFormData.phone &&
+      agreements.terms &&
+      agreements.privacy
+    );
+  }, [signupFormData, agreements]);
+
+  // 폼 제출 핸들러
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (isFormValid()) {
+        console.log('회원가입 시도:', signupFormData);
+        // TODO: 실제 회원가입 API 연동 예정
+      }
+    },
+    [isFormValid, signupFormData],
+  );
+
+  return {
+    // 상태
+    signupFormData,
+    agreements,
+    brandGuide,
+    brandGuideType,
+
+    // 핸들러
+    handleInputChange,
+    handleAgreementChange,
+    handleBrandDuplicateCheck,
+    handleSubmit,
+
+    // 유효성 검사
+    isFormValid: isFormValid(),
+  };
+};

--- a/src/lib/format-utils.ts
+++ b/src/lib/format-utils.ts
@@ -1,0 +1,29 @@
+// 전화번호 자동 하이픈 포맷팅 함수
+export const formatPhoneNumber = (value: string) => {
+  // 숫자만 추출
+  const numbers = value.replace(/[^0-9]/g, '');
+
+  // 길이에 따라 하이픈 추가
+  if (numbers.length <= 3) {
+    return numbers;
+  } else if (numbers.length <= 7) {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
+  } else {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7, 11)}`;
+  }
+};
+
+// 사업자등록번호 자동 하이픈 포맷팅 함수
+export const formatBusinessNumber = (value: string) => {
+  // 숫자만 추출
+  const numbers = value.replace(/[^0-9]/g, '');
+
+  // 길이에 따라 하이픈 추가 (123-45-67890 형식)
+  if (numbers.length <= 3) {
+    return numbers;
+  } else if (numbers.length <= 5) {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
+  } else {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3, 5)}-${numbers.slice(5, 10)}`;
+  }
+};

--- a/src/lib/password-utils.ts
+++ b/src/lib/password-utils.ts
@@ -1,0 +1,43 @@
+// 비밀번호 조건 체크 함수들
+export const checkPasswordLength = (password: string): boolean => {
+  return Boolean(password && password.length >= 8);
+};
+
+export const checkPasswordHasLetter = (password: string): boolean => {
+  return Boolean(password && /[a-zA-Z]/.test(password));
+};
+
+export const checkPasswordHasNumber = (password: string): boolean => {
+  return Boolean(password && /[0-9]/.test(password));
+};
+
+export const checkPasswordHasSpecial = (password: string): boolean => {
+  return Boolean(password && /[!@#$%^&*(),.?":{}|<>]/.test(password));
+};
+
+export const isPasswordValid = (password: string): boolean => {
+  return (
+    checkPasswordLength(password) &&
+    checkPasswordHasLetter(password) &&
+    checkPasswordHasNumber(password) &&
+    checkPasswordHasSpecial(password)
+  );
+};
+
+// 비밀번호 일치 여부 확인
+export const isPasswordMatch = (password: string, passwordConfirm: string) => {
+  return password && passwordConfirm && password === passwordConfirm;
+};
+
+// 비밀번호 확인 메시지
+export const getPasswordConfirmMessage = (password: string, passwordConfirm: string) => {
+  if (!passwordConfirm) return '';
+  if (password === passwordConfirm) {
+    return '비밀번호가 일치합니다.';
+  } else {
+    return '비밀번호가 일치하지 않습니다.';
+  }
+};
+
+// 글자 수 표시 함수
+export const getLength = (value: string, max: number) => `${value?.length || 0}/${max}자`;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,0 +1,58 @@
+// 폼 필드 타입 정의
+export type FormFieldType =
+  | 'email'
+  | 'password'
+  | 'passwordConfirm'
+  | 'brand'
+  | 'company'
+  | 'ceo'
+  | 'businessNumber'
+  | 'phone'
+  | 'zipcode'
+  | 'addressRoad'
+  | 'addressJibun'
+  | 'addressDetail';
+
+// 약관 동의 타입 정의
+export type AgreementType = 'all' | 'terms' | 'privacy' | 'marketing';
+
+// 브랜드 가이드 타입 정의
+export type BrandGuideType = 'guide' | 'success' | 'error';
+
+// 헬퍼 텍스트 타입 정의
+export type HelperTextType = 'base' | 'success' | 'error';
+
+// 회원가입 폼 데이터 타입 정의
+export interface SignupFormData {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  brand: string;
+  company: string;
+  ceo: string;
+  businessNumber: string;
+  phone: string;
+  zipcode: string;
+  addressRoad: string;
+  addressJibun: string;
+  addressDetail: string;
+}
+
+// 약관 동의 데이터 타입 정의
+export interface AgreementData {
+  all: boolean;
+  terms: boolean;
+  privacy: boolean;
+  marketing: boolean;
+}
+
+// 폼 필드 설정 타입 정의
+export interface FormFieldConfig {
+  label: string;
+  required: boolean;
+  maxLength: number;
+  placeholder: string;
+  type: 'text' | 'email' | 'password' | 'tel';
+  helperText?: string;
+  characterCount?: boolean;
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #19

## 🚩 Summary
![image](https://github.com/user-attachments/assets/4e69857c-6bc6-4ae8-af5d-d5977132ae15)

- 회원가입 폼을 재사용 가능한 FormField 컴포넌트로 리팩토링하여 코드 중복 제거 및 일관성 향상
- 비밀번호 조건 표시를 PasswordStrengthIndicator 컴포넌트로 분리하여 관심사 분리 및 재사용성 개선
- useSignupForm 훅으로 폼 상태 관리 및 유효성 검사 로직을 분리하여 성능 최적화
- 헬퍼 텍스트와 글자 수를 한 줄에 양 끝 배치하는 레이아웃 개선으로 UX 향상
- TypeScript 타입 정의를 별도 파일로 분리하여 타입 안정성 강화

## 🛠️ Technical Concerns

- FormField 컴포넌트의 props 인터페이스 설계 시 재사용성과 확장성 고려
- useSignupForm 훅에서 상태 업데이트 최적화를 위한 useCallback 사용
- 비밀번호 조건 검증 로직의 성능 최적화
- 타입 정의 시 유니온 타입과 제네릭을 활용한 타입 안전성 확보

## 🙂 To Reviewer
@taehyun32 
백엔드 유효성 검증에 맞춰서 프론트도 수정했습니다! 하는김에 리팩토링으로 구조 분리를 해봤어요!

## 📋 To Do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 새로운 폼 필드 UI 컴포넌트와 비밀번호 강도 표시 기능이 추가되었습니다.
  * 회원가입 폼 입력값 자동 포맷팅(전화번호, 사업자번호)이 적용되었습니다.

* **Refactor**
  * 회원가입 폼의 상태 관리와 입력 핸들러가 커스텀 훅으로 분리되어 코드 구조가 개선되었습니다.
  * 폼 스타일이 일관성 있게 통일되었습니다.

* **Style**
  * 폼 요소(입력창, 버튼, 체크박스 등)의 스타일이 개선되어 UI가 더욱 일관되고 보기 좋아졌습니다.

* **Chores**
  * 웹킷 브라우저 자동완성 스타일이 개선되어 입력 필드의 기본 노란색 배경이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->