### PR TITLE
마이페이지 반응형 개선

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -8,6 +8,7 @@ import { NoFooterLayout } from '@/components/layout/layouts';
 import { Sidebar } from '@/components/mypage/Sidebar';
 import { MobileSidebarList } from '@/components/mypage/MobileSidebarList';
 import { myPageData } from '@/data/mypage';
+import { ProfileCard } from '@/components/mypage/ProfileCard';
 
 export default function MyPage() {
   const { profile, orderStatuses, profileActions } = myPageData;
@@ -22,57 +23,7 @@ export default function MyPage() {
         {/* 메인 컨텐츠 */}
         <main className="mx-auto mt-0 flex w-full max-w-3xl flex-col gap-8 px-0 lg:mt-0">
           {/* 프로필 카드 */}
-          <Card className="w-full rounded-2xl border-0 bg-bg-100 px-4 py-6 shadow-sm md:px-8">
-            <CardContent className="p-0">
-              <div className="mb-6 flex items-center justify-between">
-                {/* 아바타/닉네임/뱃지 */}
-                <div className="flex items-center gap-4 md:gap-6">
-                  <Avatar className="h-12 w-12 bg-bg-300 md:h-16 md:w-16">
-                    <AvatarImage src={profile.avatar} />
-                    <AvatarFallback>{profile.nickname[0]}</AvatarFallback>
-                  </Avatar>
-                  <div>
-                    <div className="mb-1 text-lg font-semibold text-text-100 md:text-2xl">
-                      {profile.nickname}
-                    </div>
-                    <div className="flex gap-1 md:gap-2">
-                      {profile.badges.map((badge) => (
-                        <Badge
-                          key={badge}
-                          className="rounded-full border border-primary-300 bg-primary-100 px-2 py-1 text-xs font-semibold text-primary-300 md:px-3"
-                        >
-                          {badge}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-                {/* 포인트 */}
-                <div className="flex flex-col items-center">
-                  <span className="mb-1 flex h-6 w-6 items-center justify-center rounded-full border border-primary-200 text-base font-bold text-primary-200 md:h-8 md:w-8 md:text-lg">
-                    P
-                  </span>
-                  <span className="text-xs text-text-300">우르르 포인트</span>
-                  <span className="text-base font-bold tracking-tight text-text-100 md:text-xl">
-                    {profile.points.toLocaleString()}P
-                  </span>
-                </div>
-              </div>
-              {/* 하단 버튼 */}
-              <div className="flex w-full gap-2 md:gap-4">
-                {profileActions.map((action) => (
-                  <Button
-                    key={action.label}
-                    variant="outline"
-                    className="h-10 flex-1 rounded-lg border-bg-300 bg-bg-100 text-sm font-medium text-text-300 hover:border-primary-300 hover:text-primary-300 md:h-12 md:rounded-xl md:text-base"
-                    aria-label={`${action.label} 페이지로 이동`}
-                  >
-                    {action.label}
-                  </Button>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+          <ProfileCard />
 
           {/* 주문/배송 카드 */}
           <Card className="w-full rounded-2xl border-0 bg-bg-100 py-6 shadow-none">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
-import { ChevronRightIcon } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { NoFooterLayout } from '@/components/layout/layouts';
 import { Sidebar } from '@/components/mypage/Sidebar';
 import { MobileSidebarList } from '@/components/mypage/MobileSidebarList';
-import { myPageData } from '@/data/mypage';
 import { ProfileCard } from '@/components/mypage/ProfileCard';
+import { OrderStatus } from '@/components/mypage/OrderStatus';
 
 export default function MyPage() {
-  const { profile, orderStatuses, profileActions } = myPageData;
-
   return (
     <NoFooterLayout className="bg-bg-100">
       <div className="mx-auto flex w-full max-w-[1248px] flex-col items-start justify-center gap-0 px-6 py-12 md:px-9 lg:flex-row lg:gap-12 lg:px-12">
@@ -26,33 +19,7 @@ export default function MyPage() {
           <ProfileCard />
 
           {/* 주문/배송 카드 */}
-          <Card className="w-full rounded-2xl border-0 bg-bg-100 py-6 shadow-none">
-            <CardHeader className="mb-4 flex flex-row items-center justify-between p-0">
-              <CardTitle className="text-lg font-semibold text-text-100 md:text-xl">
-                주문/배송 조회
-              </CardTitle>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-auto border-bg-300 px-2 py-1 text-sm text-text-300 hover:text-primary-300"
-                aria-label="주문/배송 전체보기"
-              >
-                전체보기 <ChevronRightIcon className="ml-0 h-4 w-4" />
-              </Button>
-            </CardHeader>
-            <CardContent className="p-0 pt-4">
-              <div className="flex items-center justify-between">
-                {orderStatuses.map((item) => (
-                  <div key={item.label} className="flex flex-1 flex-col items-center">
-                    <span className="mb-1 text-2xl font-bold text-text-100 md:text-3xl">
-                      {item.count}
-                    </span>
-                    <span className="text-xs text-text-300">{item.label}</span>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+          <OrderStatus />
 
           {/* 모바일/태블릿: 사이드바 리스트 */}
           <MobileSidebarList />

--- a/src/components/mypage/OrderStatus.tsx
+++ b/src/components/mypage/OrderStatus.tsx
@@ -1,31 +1,39 @@
+import React from 'react';
+import { ChevronRightIcon } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { myPageData } from '@/data/mypage';
-import { ChevronRight } from 'lucide-react';
 
 export function OrderStatus() {
   const { orderStatuses } = myPageData;
-  const statusItems = orderStatuses;
 
   return (
-    <section className="w-full bg-transparent">
-      <div className="mb-2 flex items-center justify-between px-1">
-        <span className="text-base font-semibold text-gray-900">주문/배송 조회</span>
+    <Card className="w-full rounded-2xl border-0 bg-bg-100 py-6 shadow-none">
+      <CardHeader className="mb-4 flex flex-row items-center justify-between p-0">
+        <CardTitle className="text-lg font-semibold text-text-100 md:text-xl">
+          주문/배송 조회
+        </CardTitle>
         <Button
           variant="ghost"
           size="sm"
-          className="h-auto px-2 py-1 text-gray-400 hover:text-pink-500"
+          className="h-auto border-bg-300 px-2 py-1 text-sm text-text-300 hover:text-primary-300"
+          aria-label="주문/배송 전체보기"
         >
-          전체보기 <ChevronRight className="ml-1 h-4 w-4" />
+          전체보기 <ChevronRightIcon className="ml-0 h-4 w-4" />
         </Button>
-      </div>
-      <div className="flex items-center justify-between rounded-2xl bg-white px-4 py-5 shadow-[0_4px_24px_0_rgba(0,0,0,0.06)]">
-        {statusItems.map((item) => (
-          <div key={item.label} className="flex flex-1 flex-col items-center">
-            <span className="mb-1 text-2xl font-bold text-gray-900">{item.count}</span>
-            <span className="text-xs text-gray-500">{item.label}</span>
-          </div>
-        ))}
-      </div>
-    </section>
+      </CardHeader>
+      <CardContent className="p-0 pt-4">
+        <div className="flex items-center justify-between">
+          {orderStatuses.map((item) => (
+            <div key={item.label} className="flex flex-1 flex-col items-center">
+              <span className="mb-1 text-2xl font-bold text-text-100 md:text-3xl">
+                {item.count}
+              </span>
+              <span className="text-xs text-text-300">{item.label}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -1,57 +1,64 @@
-import Image from 'next/image';
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { myPageData } from '@/data/mypage';
 
 export function ProfileCard() {
-  const { profile } = myPageData;
+  const { profile, profileActions } = myPageData;
 
   return (
-    <section className="mx-auto flex w-full max-w-xl flex-col items-center rounded-xl bg-white px-5 py-4 shadow-[0_2px_12px_0_rgba(0,0,0,0.04)]">
-      {/* 상단: 아바타/닉네임/뱃지/포인트 */}
-      <div className="mb-4 flex w-full items-center justify-between">
-        {/* 아바타+닉네임+뱃지 */}
-        <div className="flex items-center gap-4">
-          <div className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-black">
-            <Image src={profile.avatar} alt="아바타" width={48} height={48} />
-          </div>
-          <div className="flex flex-col gap-1">
-            <div className="text-lg font-extrabold text-gray-900">{profile.nickname}</div>
-            <div className="flex gap-1">
-              {profile.badges.map((badge) => (
-                <span
-                  key={badge}
-                  className="rounded-full border border-pink-400 bg-white px-2 py-0.5 text-xs font-semibold text-pink-400"
-                >
-                  {badge}
-                </span>
-              ))}
+    <Card className="w-full rounded-2xl border-0 bg-bg-100 px-4 py-6 shadow-sm md:px-8">
+      <CardContent className="p-0">
+        <div className="mb-6 flex items-center justify-between">
+          {/* 아바타/닉네임/뱃지 */}
+          <div className="flex items-center gap-4 md:gap-6">
+            <Avatar className="h-12 w-12 bg-bg-300 md:h-16 md:w-16">
+              <AvatarImage src={profile.avatar} />
+              <AvatarFallback>{profile.nickname[0]}</AvatarFallback>
+            </Avatar>
+            <div>
+              <div className="mb-1 text-lg font-semibold text-text-100 md:text-2xl">
+                {profile.nickname}
+              </div>
+              <div className="flex gap-1 md:gap-2">
+                {profile.badges.map((badge) => (
+                  <Badge
+                    key={badge}
+                    className="rounded-full border border-primary-300 bg-primary-100 px-1.5 py-0.5 text-[10px] font-semibold text-primary-300 md:px-3 md:py-1 md:text-xs"
+                  >
+                    {badge}
+                  </Badge>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-        {/* 포인트 */}
-        <div className="flex flex-col items-end">
-          <div className="mb-0.5 flex items-center gap-1">
-            <span className="flex h-6 w-6 items-center justify-center rounded-full border border-pink-300 text-base font-bold text-pink-400">
+          {/* 포인트 */}
+          <div className="flex flex-col items-center">
+            <span className="mb-1 flex h-6 w-6 items-center justify-center rounded-full border border-primary-200 text-base font-bold text-primary-200 md:h-8 md:w-8 md:text-lg">
               P
             </span>
-          </div>
-          <div className="text-xs text-gray-400">우르르 포인트</div>
-          <div className="text-base font-extrabold tracking-tight text-gray-900">
-            {profile.points.toLocaleString()}P
+            <span className="text-xs text-text-300">우르르 포인트</span>
+            <span className="text-base font-bold tracking-tight text-text-100 md:text-xl">
+              {profile.points.toLocaleString()}P
+            </span>
           </div>
         </div>
-      </div>
-      {/* 하단: 3개 버튼 */}
-      <div className="mt-1 flex w-full gap-2">
-        <button className="flex h-10 flex-1 items-center justify-center rounded-lg border border-gray-200 bg-white text-sm font-semibold text-gray-400 transition-colors hover:border-pink-300 hover:text-pink-400">
-          나의 리뷰
-        </button>
-        <button className="flex h-10 flex-1 items-center justify-center rounded-lg border border-gray-200 bg-white text-sm font-semibold text-gray-400 transition-colors hover:border-pink-300 hover:text-pink-400">
-          프로필 수정
-        </button>
-        <button className="flex h-10 flex-1 items-center justify-center rounded-lg border border-gray-200 bg-white text-sm font-semibold text-gray-400 transition-colors hover:border-pink-300 hover:text-pink-400">
-          뷰티 프로필
-        </button>
-      </div>
-    </section>
+        {/* 하단 버튼 */}
+        <div className="flex w-full gap-1 md:gap-4">
+          {profileActions.map((action) => (
+            <Button
+              key={action.label}
+              variant="outline"
+              className="h-8 flex-1 rounded-lg border-bg-300 bg-bg-100 px-1 text-[10px] font-medium text-text-300 hover:border-primary-300 hover:text-primary-300 md:h-12 md:rounded-xl md:px-2 md:text-base"
+              aria-label={`${action.label} 페이지로 이동`}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #23

## 🚩 Summary
![image](https://github.com/user-attachments/assets/cf4f4de5-5b9d-48de-a0dc-c79021f273d6)

- 마이페이지 컴포넌트 분리 및 통합: ProfileCard, OrderStatus, MobileSidebarList, Sidebar 컴포넌트를 완전히 분리하여 재사용성과 유지보수성 향상
- 모바일 반응형 개선: 375px 이하 모바일 환경에서 ProfileCard의 버튼과 뱃지 크기 최적화
- 코드 정리: page.tsx에서 불필요한 import 제거 및 중복 코드 제거로 코드 가독성 향상

## 🛠️ Technical Concerns

- 컴포넌트 분리: 마이페이지의 각 섹션을 독립적인 컴포넌트로 분리하여 관심사 분리 원칙 적용
- 반응형 디자인: Tailwind CSS의 반응형 클래스를 활용하여 모바일(375px 이하)과 데스크탑 환경에 최적화된 UI 제공

## 🙂 To Reviewer
@songcw8 
기존에 컴포넌트로 분리해놓고 사용하지 않았던 것들.. 페이지에 반영했습니다! 반응형도 개선했어요 (특히 모바일)

## 📋 To Do


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩터**
  * 마이페이지의 프로필 카드와 주문/배송 조회 영역이 각각 별도의 컴포넌트로 분리되어 구조가 간결해졌습니다.
  * 프로필 카드와 주문/배송 조회 UI가 카드 형태로 개선되어 레이아웃과 스타일이 향상되었습니다.
  * 버튼, 뱃지, 아바타 등 주요 UI 요소의 접근성과 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->