### PR TITLE
배송지 등록 페이지 UI 구현

### DIFF
--- a/src/app/mypage/address-register/layout.tsx
+++ b/src/app/mypage/address-register/layout.tsx
@@ -1,0 +1,20 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '배송지 등록',
+  description: '우르르에서 새로운 배송지를 등록하세요.',
+  keywords: ['배송지', '주소', '등록', '우르르'],
+  openGraph: {
+    title: '배송지 등록 | 우르르',
+    description: '우르르에서 새로운 배송지를 등록하세요.',
+    type: 'website',
+  },
+  robots: {
+    index: false, // 마이페이지는 검색엔진에서 제외
+    follow: false,
+  },
+};
+
+export default function AddressRegisterLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/mypage/address-register/page.tsx
+++ b/src/app/mypage/address-register/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import React from 'react';
+import { FormField } from '@/components/form/FormField';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Sidebar } from '@/components/mypage/Sidebar';
+import { NoFooterLayout } from '@/components/layout/layouts';
+import { Card, CardContent } from '@/components/ui/card';
+import { FORM_STYLES } from '@/constants/form-styles';
+import { formatPhoneNumber } from '@/lib/format-utils';
+import { VALIDATION_CONSTANTS } from '@/constants/validation';
+import { useAddressRegister } from '@/hooks/useAddressRegister';
+
+export default function AddressRegisterPage() {
+  const { addressData, handleInputChange, handleCheckboxChange, handleSubmit, isFormValid } =
+    useAddressRegister();
+
+  return (
+    <NoFooterLayout className="bg-bg-100">
+      <div className="mx-auto flex w-full max-w-[1248px] flex-col items-start justify-center gap-0 px-6 py-12 md:px-9 lg:flex-row lg:gap-12 lg:px-12">
+        {/* 데스크탑: 사이드바 */}
+        <div className="hidden w-[256px] flex-shrink-0 pt-8 lg:block">
+          <Sidebar />
+        </div>
+        {/* 메인 컨텐츠 */}
+        <main className="mx-auto mt-0 flex w-full max-w-3xl flex-col gap-8 px-0 lg:mt-0">
+          <Card className="w-full rounded-2xl border-0 bg-bg-100 px-4 py-6 shadow-none md:px-8">
+            <CardContent className="p-0">
+              <h1 className="mb-6 text-center text-2xl font-semibold md:text-2xl">배송지 등록</h1>
+
+              <form onSubmit={handleSubmit} className="w-full space-y-6">
+                {/* 3-1. 배송지명 */}
+                <FormField
+                  label="배송지명"
+                  required
+                  characterCount={{
+                    current: addressData.addressName.length,
+                    max: 20,
+                  }}
+                >
+                  <Input
+                    type="text"
+                    placeholder="EX) 우리집"
+                    value={addressData.addressName}
+                    onChange={(e) => handleInputChange('addressName', e.target.value)}
+                    maxLength={20}
+                    className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
+                    required
+                  />
+                </FormField>
+
+                {/* 3-2. 기본 배송지 설정 */}
+                <div className="space-y-3">
+                  <label className={FORM_STYLES.checkbox.container}>
+                    <input
+                      type="checkbox"
+                      checked={addressData.isDefault}
+                      onChange={(e) => handleCheckboxChange('isDefault', e.target.checked)}
+                      className={FORM_STYLES.checkbox.base}
+                    />
+                    <span className={FORM_STYLES.checkbox.label}>기본 배송지로 설정</span>
+                  </label>
+                </div>
+
+                {/* 3-3. 연락처 */}
+                <FormField
+                  label="연락처"
+                  required
+                  helperText="하이픈(-)을 제외하고 숫자만 입력해주세요"
+                  characterCount={{
+                    current: addressData.phone.length,
+                    max: VALIDATION_CONSTANTS.PHONE.MAX_LENGTH,
+                  }}
+                >
+                  <Input
+                    type="tel"
+                    placeholder="010-0000-0000"
+                    value={formatPhoneNumber(addressData.phone)}
+                    onChange={(e) =>
+                      handleInputChange('phone', e.target.value.replace(/[^0-9]/g, ''))
+                    }
+                    maxLength={VALIDATION_CONSTANTS.PHONE.FORMATTED_MAX_LENGTH}
+                    className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
+                    required
+                  />
+                </FormField>
+
+                {/* 3-4. 주소 */}
+                <FormField label="주소" required>
+                  <div className="mb-2 flex gap-2">
+                    <div className={FORM_STYLES.zipcode.display}>
+                      {addressData.zipcode || '우편번호'}
+                    </div>
+                    <button
+                      type="button"
+                      className={FORM_STYLES.button.pinkOutline + ' h-12 min-w-[120px] rounded-lg'}
+                    >
+                      우편 번호
+                    </button>
+                  </div>
+                  <Input
+                    type="text"
+                    placeholder="도로명"
+                    value={addressData.addressRoad}
+                    onChange={(e) => handleInputChange('addressRoad', e.target.value)}
+                    className={FORM_STYLES.input.base + ' mb-2'}
+                    required
+                  />
+                  <Input
+                    type="text"
+                    placeholder="지번"
+                    value={addressData.addressJibun}
+                    onChange={(e) => handleInputChange('addressJibun', e.target.value)}
+                    className={FORM_STYLES.input.base}
+                    required
+                  />
+                </FormField>
+
+                {/* 3-5. 상세주소 */}
+                <FormField label="상세주소" required>
+                  <Input
+                    type="text"
+                    placeholder="상세주소를 입력해주세요"
+                    value={addressData.addressDetail}
+                    onChange={(e) => handleInputChange('addressDetail', e.target.value)}
+                    className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
+                    required
+                  />
+                </FormField>
+
+                {/* 저장 버튼 */}
+                <Button
+                  type="submit"
+                  disabled={!isFormValid()}
+                  className={FORM_STYLES.button.submit + ' mt-6 text-sm font-medium'}
+                >
+                  저장하기
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </main>
+      </div>
+    </NoFooterLayout>
+  );
+}

--- a/src/components/mypage/MobileSidebarList.tsx
+++ b/src/components/mypage/MobileSidebarList.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
 import { myPageData } from '@/data/mypage';
+import Link from 'next/link';
 
 // 아이콘 매핑 함수
 const getIcon = (iconName: string) => {
@@ -39,18 +40,39 @@ export function MobileSidebarList() {
         <React.Fragment key={section.title}>
           <div className="flex w-full flex-col items-start gap-3">
             <div className="mb-1 text-base font-semibold text-text-100">{section.title}</div>
-            {section.items.map((item) => (
-              <div
-                key={item.label}
-                className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-text-200 hover:bg-bg-300 md:text-base"
-                role="button"
-                tabIndex={0}
-                aria-label={`${item.label} 메뉴로 이동`}
-              >
-                {getIcon(item.icon)}
-                <span>{item.label}</span>
-              </div>
-            ))}
+            {section.items.map((item) => {
+              const content = (
+                <>
+                  {getIcon(item.icon)}
+                  <span>{item.label}</span>
+                </>
+              );
+
+              if (item.href) {
+                return (
+                  <Link
+                    key={item.label}
+                    href={item.href}
+                    className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-text-200 hover:bg-bg-300 md:text-base"
+                    aria-label={`${item.label} 메뉴로 이동`}
+                  >
+                    {content}
+                  </Link>
+                );
+              }
+
+              return (
+                <div
+                  key={item.label}
+                  className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-text-200 hover:bg-bg-300 md:text-base"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${item.label} 메뉴로 이동`}
+                >
+                  {content}
+                </div>
+              );
+            })}
           </div>
           {idx < navigationSections.length - 1 && <Separator className="my-2 bg-bg-300" />}
         </React.Fragment>

--- a/src/components/mypage/Sidebar.tsx
+++ b/src/components/mypage/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { Separator } from '@/components/ui/separator';
 import { myPageData } from '@/data/mypage';
+import Link from 'next/link';
 
 // 아이콘 매핑 함수
 const getIcon = (iconName: string) => {
@@ -39,18 +40,39 @@ export function Sidebar() {
         <React.Fragment key={section.title}>
           <div className="flex w-full flex-col items-start gap-3">
             <div className="mb-1 text-base font-semibold text-text-100">{section.title}</div>
-            {section.items.map((item) => (
-              <div
-                key={item.label}
-                className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-text-200 hover:bg-bg-200 md:text-base"
-                role="button"
-                tabIndex={0}
-                aria-label={`${item.label} 메뉴로 이동`}
-              >
-                {getIcon(item.icon)}
-                <span>{item.label}</span>
-              </div>
-            ))}
+            {section.items.map((item) => {
+              const content = (
+                <>
+                  {getIcon(item.icon)}
+                  <span>{item.label}</span>
+                </>
+              );
+
+              if (item.href) {
+                return (
+                  <Link
+                    key={item.label}
+                    href={item.href}
+                    className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-text-200 hover:bg-bg-200 md:text-base"
+                    aria-label={`${item.label} 메뉴로 이동`}
+                  >
+                    {content}
+                  </Link>
+                );
+              }
+
+              return (
+                <div
+                  key={item.label}
+                  className="flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-text-200 hover:bg-bg-200 md:text-base"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${item.label} 메뉴로 이동`}
+                >
+                  {content}
+                </div>
+              );
+            })}
           </div>
           {idx < navigationSections.length - 1 && <Separator className="my-2 bg-bg-300" />}
         </React.Fragment>

--- a/src/data/mypage.ts
+++ b/src/data/mypage.ts
@@ -1,3 +1,15 @@
+// 마이페이지 아이템 타입 정의
+interface NavigationItem {
+  icon: string;
+  label: string;
+  href?: string;
+}
+
+interface NavigationSection {
+  title: string;
+  items: NavigationItem[];
+}
+
 // 마이페이지 mock 데이터
 export const myPageData = {
   // 프로필 정보
@@ -26,7 +38,7 @@ export const myPageData = {
         { icon: 'RefreshCwIcon', label: '취소/반품 내역' },
         { icon: 'PointIcon', label: '우르르 포인트 내역' },
         { icon: 'MessageSquareIcon', label: '나의 리뷰' },
-        { icon: 'TruckIcon', label: '배송지 관리' },
+        { icon: 'TruckIcon', label: '배송지 관리', href: '/mypage/address-register' },
       ],
     },
     {

--- a/src/hooks/useAddressRegister.ts
+++ b/src/hooks/useAddressRegister.ts
@@ -1,0 +1,72 @@
+import { useState, useCallback } from 'react';
+
+interface AddressFormData {
+  addressName: string;
+  isDefault: boolean;
+  phone: string;
+  zipcode: string;
+  addressRoad: string;
+  addressJibun: string;
+  addressDetail: string;
+}
+
+const INITIAL_ADDRESS_DATA: AddressFormData = {
+  addressName: '',
+  isDefault: true,
+  phone: '',
+  zipcode: '',
+  addressRoad: '',
+  addressJibun: '',
+  addressDetail: '',
+};
+
+export const useAddressRegister = () => {
+  const [addressData, setAddressData] = useState<AddressFormData>(INITIAL_ADDRESS_DATA);
+
+  const handleInputChange = useCallback((field: keyof AddressFormData, value: string) => {
+    setAddressData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  }, []);
+
+  const handleCheckboxChange = useCallback((field: keyof AddressFormData, checked: boolean) => {
+    setAddressData((prev) => ({
+      ...prev,
+      [field]: checked,
+    }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      // TODO: 실제 배송지 등록 API 연동 필요
+      console.log('배송지 등록:', addressData);
+    },
+    [addressData],
+  );
+
+  const resetForm = useCallback(() => {
+    setAddressData(INITIAL_ADDRESS_DATA);
+  }, []);
+
+  const isFormValid = useCallback(() => {
+    return (
+      addressData.addressName.trim() !== '' &&
+      addressData.phone.trim() !== '' &&
+      addressData.zipcode.trim() !== '' &&
+      addressData.addressRoad.trim() !== '' &&
+      addressData.addressJibun.trim() !== '' &&
+      addressData.addressDetail.trim() !== ''
+    );
+  }, [addressData]);
+
+  return {
+    addressData,
+    handleInputChange,
+    handleCheckboxChange,
+    handleSubmit,
+    resetForm,
+    isFormValid,
+  };
+};


### PR DESCRIPTION
## ⭐️ Issue Number
- #30

## 🚩 Summary
![image](https://github.com/user-attachments/assets/bc1efe02-a86d-41ca-ad9b-84184bddadf5)

배송지 등록 페이지를 구현하여 사용자가 새로운 배송지를 등록할 수 있는 기능을 추가했습니다.

- ✅ 배송지명 입력 (최대 20자, 실시간 글자수 카운트)
- ✅ 기본 배송지 설정 체크박스
- ✅ 연락처 입력 (전화번호 자동 포맷팅)
- ✅ 주소 입력 (우편번호, 도로명, 지번)
- ✅ 상세주소 입력
- ✅ 폼 유효성 검사 및 실시간 검증
- ✅ 마이페이지 사이드바 네비게이션 연결

## 🛠️ Technical Concerns

- useAddressRegister 커스텀 훅으로 폼 상태 관리

## 🙂 To Reviewer
@songcw8 빠르게 화면 검토만 부탁드립니다.

## 📋 To Do

- [ ] 배송지 목록 페이지 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에 배송지 등록 페이지가 추가되었습니다. 사용자는 배송지 이름, 기본 배송지 설정, 전화번호, 우편번호, 도로명/지번/상세 주소를 입력하여 배송지를 등록할 수 있습니다.
  * 마이페이지 내비게이션에 ‘배송지 관리’ 항목이 추가되어, 해당 페이지로 쉽게 이동할 수 있습니다.

* **개선 사항**
  * 마이페이지 사이드바 및 모바일 사이드바에서 내비게이션 항목이 링크로 동작하도록 개선되어, 관련 페이지로 바로 이동할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->