### PR TITLE
SidebarItem onClick 타입 에러 수정

### DIFF
--- a/src/components/common/SidebarItem.tsx
+++ b/src/components/common/SidebarItem.tsx
@@ -9,9 +9,10 @@ interface SidebarItemProps {
     href?: string;
   };
   className?: string;
+  onClick?: () => void;
 }
 
-export function SidebarItem({ item, className = '' }: SidebarItemProps) {
+export function SidebarItem({ item, className = '', onClick }: SidebarItemProps) {
   const content = (
     <>
       <SidebarIcon iconName={item.icon} />
@@ -25,6 +26,7 @@ export function SidebarItem({ item, className = '' }: SidebarItemProps) {
         href={item.href}
         className={`flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-text-200 hover:bg-bg-200 md:text-base ${className}`}
         aria-label={`${item.label} 메뉴로 이동`}
+        onClick={onClick}
       >
         {content}
       </Link>
@@ -37,6 +39,7 @@ export function SidebarItem({ item, className = '' }: SidebarItemProps) {
       role="button"
       tabIndex={0}
       aria-label={`${item.label} 메뉴로 이동`}
+      onClick={onClick}
     >
       {content}
     </div>


### PR DESCRIPTION
## ⭐️ Issue Number

- #65 

## 🚩 Summary
- SidebarItem 컴포넌트에 onClick prop이 정의되어 있지 않아, Sidebar에서 onClick을 전달할 때 타입 에러가 발생했습니다.
- SidebarItemProps에 onClick?: () => void;를 추가하고, 컴포넌트 내부에서 onClick을 처리하도록 수정했습니다.
- Sidebar.tsx에서 로그아웃 등 클릭 이벤트가 필요한 경우 onClick을 정상적으로 전달할 수 있도록 반영했습니다.
- 이로 인해 Vercel 타입 에러 및 빌드 실패 문제가 해결됩니다.

## 🛠 Technical Concerns
- onClick prop은 선택적(optional)로 처리하여 기존 href 기반 네비게이션에는 영향이 없습니다.
- 타입 안전성을 위해 SidebarItemProps에 명확히 타입을 추가했습니다.

## 🙂 To Reviewer
- 혹시 추가적으로 타입 관련 리팩터링이 필요한 부분이 있다면 코멘트 부탁드립니다.
- Vercel 배포가 정상적으로 되는지 꼭 확인 부탁드립니다.

## 📋 To Do
- [x] SidebarItemProps에 onClick prop 추가
- [x] SidebarItem에서 onClick prop 처리
- [x] Sidebar.tsx에서 onClick 전달 방식 수정
- [x] 타입 에러 해결 확인
- [x] Vercel 배포 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사이드바 항목에 클릭 이벤트(onClick) 핸들러를 추가하여, 링크 또는 버튼 형태 모두에서 클릭 동작을 처리할 수 있도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->