### PR TITLE
회원 정보 조회 및 수정 관련 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-day-picker": "^9.7.0",
         "react-dom": "^18",
         "sonner": "^2.0.6",
+        "swr": "^2.3.4",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^5.0.6"
@@ -2772,6 +2773,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-node-es": {
@@ -6486,6 +6496,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
@@ -6961,6 +6984,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-day-picker": "^9.7.0",
     "react-dom": "^18",
     "sonner": "^2.0.6",
+    "swr": "^2.3.4",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^5.0.6"

--- a/src/app/mypage/beauty-profile-edit/page.tsx
+++ b/src/app/mypage/beauty-profile-edit/page.tsx
@@ -5,7 +5,13 @@ import { Button } from '@/components/ui/button';
 import { MyPageLayout } from '@/components/mypage/MyPageLayout';
 import { BeautyProfileFormFields } from '@/components/mypage/beauty-profile-edit';
 import { Card, CardContent } from '@/components/ui/card';
-import { NoticeBanner, PageHeader, LoadingSkeleton } from '@/components/common';
+import {
+  NoticeBanner,
+  PageHeader,
+  LoadingSkeleton,
+  ErrorDialog,
+  SuccessDialog,
+} from '@/components/common';
 import { FORM_STYLES } from '@/constants/form-styles';
 import { useBeautyProfileEdit } from '@/hooks/useBeautyProfileEdit';
 import { AuthGuard } from '@/components/auth/AuthGuard';
@@ -14,10 +20,14 @@ function BeautyProfileEditPageContent() {
   const {
     beautyProfileData,
     isLoading,
+    errorDialog,
+    successDialog,
     handleInputChange,
     handleSkinConcernToggle,
     handleInterestCategoryToggle,
     handleSubmit,
+    closeErrorDialog,
+    closeSuccessDialog,
     SKIN_TYPE_OPTIONS,
     SKIN_TONE_OPTIONS,
     SKIN_CONCERN_OPTIONS,
@@ -75,6 +85,23 @@ function BeautyProfileEditPageContent() {
           </form>
         </CardContent>
       </Card>
+
+      {/* 에러 다이얼로그 */}
+      <ErrorDialog
+        isOpen={errorDialog.isOpen}
+        onClose={closeErrorDialog}
+        title={errorDialog.title}
+        message={errorDialog.message}
+        errorDetails={errorDialog.errorDetails}
+      />
+
+      {/* 성공 다이얼로그 */}
+      <SuccessDialog
+        isOpen={successDialog.isOpen}
+        onClose={closeSuccessDialog}
+        title={successDialog.title}
+        message={successDialog.message}
+      />
     </MyPageLayout>
   );
 }

--- a/src/app/mypage/beauty-profile-edit/page.tsx
+++ b/src/app/mypage/beauty-profile-edit/page.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { MyPageLayout } from '@/components/mypage/MyPageLayout';
 import { BeautyProfileFormFields } from '@/components/mypage/beauty-profile-edit';
 import { Card, CardContent } from '@/components/ui/card';
-import { NoticeBanner, PageHeader } from '@/components/common';
+import { NoticeBanner, PageHeader, LoadingSkeleton } from '@/components/common';
 import { FORM_STYLES } from '@/constants/form-styles';
 import { useBeautyProfileEdit } from '@/hooks/useBeautyProfileEdit';
 import { AuthGuard } from '@/components/auth/AuthGuard';
@@ -13,6 +13,7 @@ import { AuthGuard } from '@/components/auth/AuthGuard';
 function BeautyProfileEditPageContent() {
   const {
     beautyProfileData,
+    isLoading,
     handleInputChange,
     handleSkinConcernToggle,
     handleInterestCategoryToggle,
@@ -24,6 +25,19 @@ function BeautyProfileEditPageContent() {
     INTEREST_CATEGORY_OPTIONS,
     BEAUTY_PROFILE_CONSTANTS,
   } = useBeautyProfileEdit();
+
+  if (isLoading) {
+    return (
+      <MyPageLayout>
+        <Card className={FORM_STYLES.card.base}>
+          <CardContent className={FORM_STYLES.card.content}>
+            <PageHeader title="뷰티프로필 수정" />
+            <LoadingSkeleton className="h-96" />
+          </CardContent>
+        </Card>
+      </MyPageLayout>
+    );
+  }
 
   return (
     <MyPageLayout>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { MyPageLayout } from '@/components/mypage/MyPageLayout';
 import { ProfileCard } from '@/components/mypage/ProfileCard';
 import { BeautyProfileSummary } from '@/components/mypage/beauty-profile';
@@ -8,10 +8,56 @@ import { MobileSidebarList } from '@/components/mypage/MobileSidebarList';
 import { useMyPage } from '@/hooks/useMyPage';
 import { useAuthStore } from '@/store';
 import { AuthGuard } from '@/components/auth/AuthGuard';
+import api from '@/lib/axios';
+import type { UserInfo } from '@/types/auth';
 
 function MyPageContent() {
   const { hasBeautyProfile, summaryInfo } = useMyPage();
   const { user } = useAuthStore();
+  const [mypageData, setMypageData] = useState<UserInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchMyPageData = async () => {
+      try {
+        setLoading(true);
+        const response = await api.get('/members/me/mypage');
+        console.log('마이페이지 API 응답:', response.data.data);
+        setMypageData(response.data.data);
+        setError(null);
+      } catch (err) {
+        console.error('마이페이지 데이터 조회 실패:', err);
+        setError(err as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMyPageData();
+  }, []);
+
+  // 로딩 중
+  if (loading) {
+    return (
+      <MyPageLayout>
+        <div className="flex flex-1 items-center justify-center py-20">
+          <div className="text-sm text-text-200">로딩 중...</div>
+        </div>
+      </MyPageLayout>
+    );
+  }
+
+  // 에러 발생
+  if (error) {
+    return (
+      <MyPageLayout>
+        <div className="flex flex-1 items-center justify-center py-20">
+          <div className="text-sm text-text-200">데이터를 불러올 수 없습니다.</div>
+        </div>
+      </MyPageLayout>
+    );
+  }
 
   // 사용자 정보가 없는 경우
   if (!user) {
@@ -26,8 +72,8 @@ function MyPageContent() {
 
   return (
     <MyPageLayout>
-      {/* 프로필 카드 */}
-      <ProfileCard user={user} />
+      {/* 프로필 카드 - API에서 받아온 데이터 전달 */}
+      <ProfileCard user={mypageData} />
 
       {/* 뷰티 프로필 요약 카드 */}
       {hasBeautyProfile && <BeautyProfileSummary summaryInfo={summaryInfo} />}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -56,14 +56,19 @@ function MyPageContent() {
     ? {
         skinType:
           SKIN_TYPE_OPTIONS.find((opt) => opt.value === beautyProfileData.skin_type)?.label ||
-          beautyProfileData.skin_type,
+          beautyProfileData.skin_type ||
+          '없음',
         skinTone:
           SKIN_TONE_OPTIONS.find((opt) => opt.value === beautyProfileData.skin_tone)?.label ||
-          beautyProfileData.skin_tone,
+          beautyProfileData.skin_tone ||
+          '없음',
         skinConcerns: beautyProfileData.concerns || [],
         interests: beautyProfileData.interest_categories || [],
         skinReaction: beautyProfileData.has_allergy ? '있음' : '없음',
-        priceRange: `${beautyProfileData.min_price?.toLocaleString() || 0}원 ~ ${beautyProfileData.max_price?.toLocaleString() || 0}원`,
+        priceRange:
+          beautyProfileData.min_price && beautyProfileData.max_price
+            ? `${beautyProfileData.min_price.toLocaleString()}원 ~ ${beautyProfileData.max_price.toLocaleString()}원`
+            : '없음',
       }
     : null;
 

--- a/src/app/mypage/profile-edit/page.tsx
+++ b/src/app/mypage/profile-edit/page.tsx
@@ -32,6 +32,7 @@ function ProfileEditPageContent() {
     handleSubmit,
     closeErrorDialog,
     closeSuccessDialog,
+    isNicknameChanged,
     GENDER_OPTIONS,
   } = useProfileEdit();
 
@@ -64,6 +65,7 @@ function ProfileEditPageContent() {
               agreements={agreements}
               nicknameGuide={nicknameGuide}
               nicknameGuideType={nicknameGuideType}
+              isNicknameChanged={isNicknameChanged()}
               onNicknameChange={handleNicknameChange}
               onNicknameCheck={handleNicknameCheck}
               onGenderChange={setGender}

--- a/src/app/mypage/profile-edit/page.tsx
+++ b/src/app/mypage/profile-edit/page.tsx
@@ -20,6 +20,7 @@ function ProfileEditPageContent() {
     profileImg,
     nicknameGuide,
     nicknameGuideType,
+    loading,
     handleNicknameChange,
     handleNicknameCheck,
     setGender,
@@ -29,6 +30,17 @@ function ProfileEditPageContent() {
     handleSubmit,
     GENDER_OPTIONS,
   } = useProfileEdit();
+
+  // 로딩 중
+  if (loading) {
+    return (
+      <MyPageLayout>
+        <div className="flex flex-1 items-center justify-center py-20">
+          <div className="text-sm text-text-200">로딩 중...</div>
+        </div>
+      </MyPageLayout>
+    );
+  }
 
   return (
     <MyPageLayout>

--- a/src/app/mypage/profile-edit/page.tsx
+++ b/src/app/mypage/profile-edit/page.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { MyPageLayout } from '@/components/mypage/MyPageLayout';
 import { ProfileFormFields, ProfileImageUpload } from '@/components/mypage/profile-edit';
 import { Card, CardContent } from '@/components/ui/card';
-import { PageHeader } from '@/components/common';
+import { PageHeader, ErrorDialog, SuccessDialog } from '@/components/common';
 import { FORM_STYLES } from '@/constants/form-styles';
 import { useProfileEdit } from '@/hooks/useProfileEdit';
 import { AuthGuard } from '@/components/auth/AuthGuard';
@@ -21,6 +21,8 @@ function ProfileEditPageContent() {
     nicknameGuide,
     nicknameGuideType,
     loading,
+    errorDialog,
+    successDialog,
     handleNicknameChange,
     handleNicknameCheck,
     setGender,
@@ -28,6 +30,8 @@ function ProfileEditPageContent() {
     handlePhoneChange,
     handleAgreementChange,
     handleSubmit,
+    closeErrorDialog,
+    closeSuccessDialog,
     GENDER_OPTIONS,
   } = useProfileEdit();
 
@@ -78,6 +82,23 @@ function ProfileEditPageContent() {
           </form>
         </CardContent>
       </Card>
+
+      {/* 에러 다이얼로그 */}
+      <ErrorDialog
+        isOpen={errorDialog.isOpen}
+        onClose={closeErrorDialog}
+        title={errorDialog.title}
+        message={errorDialog.message}
+        errorDetails={errorDialog.errorDetails}
+      />
+
+      {/* 성공 다이얼로그 */}
+      <SuccessDialog
+        isOpen={successDialog.isOpen}
+        onClose={closeSuccessDialog}
+        title={successDialog.title}
+        message={successDialog.message}
+      />
     </MyPageLayout>
   );
 }

--- a/src/components/common/ErrorDialog.tsx
+++ b/src/components/common/ErrorDialog.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { AlertCircle } from 'lucide-react';
+
+interface ErrorDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  message: string;
+  errorDetails?: string;
+}
+
+export const ErrorDialog: React.FC<ErrorDialogProps> = ({
+  isOpen,
+  onClose,
+  title,
+  message,
+  errorDetails,
+}) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <AlertCircle className="text-destructive h-5 w-5" />
+            <DialogTitle className="text-destructive">{title}</DialogTitle>
+          </div>
+          <DialogDescription className="text-left">
+            {message}
+            {errorDetails && (
+              <div className="bg-muted mt-2 rounded p-2 text-xs">
+                <strong>상세 오류:</strong> {errorDetails}
+              </div>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={onClose} variant="outline">
+            확인
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/common/ErrorDialog.tsx
+++ b/src/components/common/ErrorDialog.tsx
@@ -30,20 +30,20 @@ export const ErrorDialog: React.FC<ErrorDialogProps> = ({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <div className="flex items-center gap-2">
-            <AlertCircle className="text-destructive h-5 w-5" />
-            <DialogTitle className="text-destructive">{title}</DialogTitle>
+            <AlertCircle className="h-5 w-5 text-primary-300" />
+            <DialogTitle className="text-text-100">{title}</DialogTitle>
           </div>
-          <DialogDescription className="text-left">
+          <DialogDescription className="text-left text-text-200">
             {message}
             {errorDetails && (
-              <div className="bg-muted mt-2 rounded p-2 text-xs">
+              <div className="mt-2 rounded bg-bg-100 p-2 text-xs text-text-300">
                 <strong>상세 오류:</strong> {errorDetails}
               </div>
             )}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button onClick={onClose} variant="outline">
+          <Button onClick={onClose} className="bg-primary-200 text-text-on hover:bg-primary-300">
             확인
           </Button>
         </DialogFooter>

--- a/src/components/common/ErrorDialog.tsx
+++ b/src/components/common/ErrorDialog.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { AlertCircle } from 'lucide-react';
+import { FORM_STYLES } from '@/constants/form-styles';
 
 interface ErrorDialogProps {
   isOpen: boolean;
@@ -43,7 +44,7 @@ export const ErrorDialog: React.FC<ErrorDialogProps> = ({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button onClick={onClose} className="bg-primary-200 text-text-on hover:bg-primary-300">
+          <Button onClick={onClose} className={FORM_STYLES.button.dialog}>
             확인
           </Button>
         </DialogFooter>

--- a/src/components/common/SuccessDialog.tsx
+++ b/src/components/common/SuccessDialog.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { CheckCircle } from 'lucide-react';
+
+interface SuccessDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  message: string;
+}
+
+export const SuccessDialog: React.FC<SuccessDialogProps> = ({
+  isOpen,
+  onClose,
+  title,
+  message,
+}) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <CheckCircle className="h-5 w-5 text-green-600" />
+            <DialogTitle className="text-green-600">{title}</DialogTitle>
+          </div>
+          <DialogDescription className="text-left">{message}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={onClose} className="bg-green-600 hover:bg-green-700">
+            확인
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/common/SuccessDialog.tsx
+++ b/src/components/common/SuccessDialog.tsx
@@ -28,13 +28,13 @@ export const SuccessDialog: React.FC<SuccessDialogProps> = ({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <div className="flex items-center gap-2">
-            <CheckCircle className="h-5 w-5 text-green-600" />
-            <DialogTitle className="text-green-600">{title}</DialogTitle>
+            <CheckCircle className="h-5 w-5 text-primary-300" />
+            <DialogTitle className="text-text-100">{title}</DialogTitle>
           </div>
-          <DialogDescription className="text-left">{message}</DialogDescription>
+          <DialogDescription className="text-left text-text-200">{message}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button onClick={onClose} className="bg-green-600 hover:bg-green-700">
+          <Button onClick={onClose} className="bg-primary-200 text-text-on hover:bg-primary-300">
             확인
           </Button>
         </DialogFooter>

--- a/src/components/common/SuccessDialog.tsx
+++ b/src/components/common/SuccessDialog.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { CheckCircle } from 'lucide-react';
+import { FORM_STYLES } from '@/constants/form-styles';
 
 interface SuccessDialogProps {
   isOpen: boolean;
@@ -34,7 +35,7 @@ export const SuccessDialog: React.FC<SuccessDialogProps> = ({
           <DialogDescription className="text-left text-text-200">{message}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button onClick={onClose} className="bg-primary-200 text-text-on hover:bg-primary-300">
+          <Button onClick={onClose} className={FORM_STYLES.button.dialog}>
             확인
           </Button>
         </DialogFooter>

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -11,6 +11,8 @@ export { PointEarnMethodAccordion } from './PointEarnMethodAccordion';
 export { PointHistorySection } from './PointHistorySection';
 export { PageHeader } from './PageHeader';
 export { EmptyState } from './EmptyState';
+export { ErrorDialog } from './ErrorDialog';
+export { SuccessDialog } from './SuccessDialog';
 export {
   LoadingSkeleton,
   CardSkeleton,

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -43,10 +43,6 @@ export function ProfileCard({ user }: ProfileCardProps) {
                 {displayName}
               </div>
               <div className="flex gap-1 md:gap-2">
-                {/* 사용자 타입에 따른 뱃지 */}
-                <Badge className="rounded-full border border-primary-300 bg-primary-100 px-1.5 py-0.5 text-[10px] font-semibold text-primary-300 md:px-3 md:py-1 md:text-xs">
-                  {userType === 'SELLER' ? '판매자' : '구매자'}
-                </Badge>
                 {/* skin_type, skin_tone 뱃지 */}
                 {skinTypeLabel && (
                   <Badge className="rounded-full border border-primary-300 bg-primary-100 px-1.5 py-0.5 text-[10px] font-semibold text-primary-300 md:px-3 md:py-1 md:text-xs">

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -8,30 +8,25 @@ import { FORM_STYLES } from '@/constants/form-styles';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import type { UserInfo } from '@/types/auth';
+import { SKIN_TYPE_OPTIONS, SKIN_TONE_OPTIONS } from '@/constants/beauty-profile';
 
 interface ProfileCardProps {
   user: UserInfo | null;
 }
 
 export function ProfileCard({ user }: ProfileCardProps) {
-  const { profile, profileActions } = myPageData;
-  const profileData = beautyProfileData.withProfile;
-  const hasBeautyProfile = profileData.skinType && profileData.skinTone;
-
-  // 사용자 정보 디버깅
-  console.log('ProfileCard - 사용자 정보:', user);
-
-  // 사용자 정보가 없으면 기본값 사용
-  const displayName = user?.nickname || profile.nickname;
-  const displayAvatar = user?.profile_image || profile.avatar;
+  // API에서 받아온 값 사용
+  const displayName = user?.member_name || user?.nickname || '이름없음';
+  const displayAvatar = user?.profile_image || '/profile-image.svg';
   const userType = user?.user_type || 'MEMBER';
+  const points = user?.points ?? 0;
+  // 한글 변환
+  const skinTypeLabel = SKIN_TYPE_OPTIONS.find((opt) => opt.value === user?.skin_type)?.label;
+  const skinToneLabel = SKIN_TONE_OPTIONS.find((opt) => opt.value === user?.skin_tone)?.label;
 
-  console.log('ProfileCard - 표시 정보:', {
-    displayName,
-    displayAvatar,
-    userType,
-    originalUser: user,
-  });
+  console.log('ProfileCard user:', user);
+  console.log('skin_type:', user?.skin_type, 'skin_tone:', user?.skin_tone);
+  console.log('skinTypeLabel:', skinTypeLabel, 'skinToneLabel:', skinToneLabel);
 
   return (
     <Card className="w-full rounded-2xl border-0 bg-bg-100 px-4 py-6 shadow-sm md:px-8">
@@ -52,15 +47,17 @@ export function ProfileCard({ user }: ProfileCardProps) {
                 <Badge className="rounded-full border border-primary-300 bg-primary-100 px-1.5 py-0.5 text-[10px] font-semibold text-primary-300 md:px-3 md:py-1 md:text-xs">
                   {userType === 'SELLER' ? '판매자' : '구매자'}
                 </Badge>
-                {/* 기존 뱃지들 */}
-                {profile.badges.map((badge) => (
-                  <Badge
-                    key={badge}
-                    className="rounded-full border border-primary-300 bg-primary-100 px-1.5 py-0.5 text-[10px] font-semibold text-primary-300 md:px-3 md:py-1 md:text-xs"
-                  >
-                    {badge}
+                {/* skin_type, skin_tone 뱃지 */}
+                {skinTypeLabel && (
+                  <Badge className="rounded-full border border-primary-300 bg-primary-100 px-1.5 py-0.5 text-[10px] font-semibold text-primary-300 md:px-3 md:py-1 md:text-xs">
+                    {skinTypeLabel}
                   </Badge>
-                ))}
+                )}
+                {skinToneLabel && (
+                  <Badge className="rounded-full border border-primary-300 bg-primary-100 px-1.5 py-0.5 text-[10px] font-semibold text-primary-300 md:px-3 md:py-1 md:text-xs">
+                    {skinToneLabel}
+                  </Badge>
+                )}
               </div>
             </div>
           </div>
@@ -71,13 +68,14 @@ export function ProfileCard({ user }: ProfileCardProps) {
             </span>
             <span className="text-xs text-text-300">우르르 포인트</span>
             <span className="text-base font-bold tracking-tight text-text-100 md:text-xl">
-              {profile.points.toLocaleString()}P
+              {points.toLocaleString()}P
             </span>
           </div>
         </div>
         {/* 하단 버튼 */}
         <div className="flex w-full flex-col gap-2 md:flex-row md:gap-4">
-          {profileActions.map((action) => (
+          {/* 기존 버튼 렌더링 유지 */}
+          {myPageData.profileActions.map((action) => (
             <Link
               key={action.label}
               href={action.href || '#'}
@@ -85,11 +83,7 @@ export function ProfileCard({ user }: ProfileCardProps) {
               aria-label={`${action.label} 페이지로 이동`}
             >
               <Button variant="outline" className={cn(FORM_STYLES.button.profileCard)}>
-                {action.label === '뷰티 프로필 수정' && hasBeautyProfile
-                  ? '뷰티 프로필 수정'
-                  : action.label === '뷰티 프로필 수정'
-                    ? '뷰티 프로필 작성'
-                    : action.label}
+                {action.label === '뷰티 프로필 수정' ? '뷰티 프로필 수정' : action.label}
               </Button>
             </Link>
           ))}

--- a/src/components/mypage/beauty-profile-edit/BeautyProfileFormFields.tsx
+++ b/src/components/mypage/beauty-profile-edit/BeautyProfileFormFields.tsx
@@ -130,28 +130,34 @@ export function BeautyProfileFormFields({
 
       {/* 3-6. 선호 가격대 */}
       <FormField label="선호 가격대" required>
-        <div className="flex gap-4">
-          <div className="flex-1">
-            <Input
-              type="number"
-              min="1"
-              placeholder="최소 가격"
-              value={beautyProfileData.minPrice}
-              onChange={(e) => onInputChange('minPrice', e.target.value)}
-              className={FORM_STYLES.input.base}
-            />
+        <div className="space-y-2">
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <Input
+                type="number"
+                min="1"
+                max="2147483639"
+                placeholder="최소 가격"
+                value={beautyProfileData.minPrice}
+                onChange={(e) => onInputChange('minPrice', e.target.value)}
+                className={FORM_STYLES.input.base}
+              />
+            </div>
+            <div className="flex items-center text-text-300">~</div>
+            <div className="flex-1">
+              <Input
+                type="number"
+                min="1"
+                max="2147483639"
+                placeholder="최대 가격"
+                value={beautyProfileData.maxPrice}
+                onChange={(e) => onInputChange('maxPrice', e.target.value)}
+                className={FORM_STYLES.input.base}
+              />
+            </div>
+            <div className="flex items-center text-text-300">원</div>
           </div>
-          <div className="flex items-center text-text-300">~</div>
-          <div className="flex-1">
-            <Input
-              type="number"
-              placeholder="최대 가격"
-              value={beautyProfileData.maxPrice}
-              onChange={(e) => onInputChange('maxPrice', e.target.value)}
-              className={FORM_STYLES.input.base}
-            />
-          </div>
-          <div className="flex items-center text-text-300">원</div>
+          <p className="text-xs text-text-200">* 최대 2,147,483,639원까지 설정 가능합니다.</p>
         </div>
       </FormField>
 

--- a/src/components/mypage/beauty-profile-edit/BeautyProfileFormFields.tsx
+++ b/src/components/mypage/beauty-profile-edit/BeautyProfileFormFields.tsx
@@ -134,6 +134,7 @@ export function BeautyProfileFormFields({
           <div className="flex-1">
             <Input
               type="number"
+              min="1"
               placeholder="최소 가격"
               value={beautyProfileData.minPrice}
               onChange={(e) => onInputChange('minPrice', e.target.value)}

--- a/src/components/mypage/beauty-profile-edit/BeautyProfileFormFields.tsx
+++ b/src/components/mypage/beauty-profile-edit/BeautyProfileFormFields.tsx
@@ -100,8 +100,8 @@ export function BeautyProfileFormFields({
           <Input
             type="text"
             placeholder="예: 알코올 파라벤 시트랄"
-            value={beautyProfileData.productRequest}
-            onChange={(e) => onInputChange('productRequest', e.target.value)}
+            value={beautyProfileData.allergyInput || ''}
+            onChange={(e) => onInputChange('allergyInput', e.target.value)}
             className={FORM_STYLES.input.base}
           />
         </FormField>

--- a/src/components/mypage/beauty-profile-edit/BeautyProfileFormFields.tsx
+++ b/src/components/mypage/beauty-profile-edit/BeautyProfileFormFields.tsx
@@ -94,6 +94,19 @@ export function BeautyProfileFormFields({
         </div>
       </FormField>
 
+      {/* 알러지 입력: 알러지가 있다고 선택한 경우에만 노출 */}
+      {beautyProfileData.skinReaction !== 'no' && (
+        <FormField label="알러지(여러 개 입력 시 공백으로 구분)">
+          <Input
+            type="text"
+            placeholder="예: 알코올 파라벤 시트랄"
+            value={beautyProfileData.productRequest}
+            onChange={(e) => onInputChange('productRequest', e.target.value)}
+            className={FORM_STYLES.input.base}
+          />
+        </FormField>
+      )}
+
       {/* 3-5. 관심 카테고리 */}
       <FormField label="관심 카테고리 (중복 선택 가능)" required>
         <div className="space-y-3">

--- a/src/components/mypage/beauty-profile/BeautyProfileSummary.tsx
+++ b/src/components/mypage/beauty-profile/BeautyProfileSummary.tsx
@@ -32,16 +32,22 @@ export function BeautyProfileSummary({ summaryInfo }: BeautyProfileSummaryProps)
           <div className="space-y-2">
             <div className="flex justify-between">
               <span className="text-sm text-text-300">피부 타입</span>
-              <span className="text-sm font-medium text-text-100">{summaryInfo.skinType}</span>
+              <span className="text-sm font-medium text-text-100">
+                {summaryInfo.skinType || '없음'}
+              </span>
             </div>
             <div className="flex justify-between">
               <span className="text-sm text-text-300">피부 톤</span>
-              <span className="text-sm font-medium text-text-100">{summaryInfo.skinTone}</span>
+              <span className="text-sm font-medium text-text-100">
+                {summaryInfo.skinTone || '없음'}
+              </span>
             </div>
             <div className="flex justify-between">
               <span className="text-sm text-text-300">피부 고민</span>
               <span className="text-sm font-medium text-text-100">
-                {summaryInfo.skinConcerns?.slice(0, 3).join(', ')}
+                {summaryInfo.skinConcerns && summaryInfo.skinConcerns.length > 0
+                  ? summaryInfo.skinConcerns.slice(0, 3).join(', ')
+                  : '없음'}
               </span>
             </div>
           </div>
@@ -57,13 +63,21 @@ export function BeautyProfileSummary({ summaryInfo }: BeautyProfileSummaryProps)
             <div className="flex justify-between">
               <span className="text-sm text-text-300">관심 카테고리</span>
               <span className="text-sm font-medium text-text-100">
-                {summaryInfo.interests?.slice(0, 2).join(', ')}
-                {summaryInfo.interests && summaryInfo.interests.length > 2 && ' 외'}
+                {summaryInfo.interests && summaryInfo.interests.length > 0
+                  ? (() => {
+                      const displayInterests = summaryInfo.interests.slice(0, 2).join(', ');
+                      return summaryInfo.interests.length > 2
+                        ? `${displayInterests} 외`
+                        : displayInterests;
+                    })()
+                  : '없음'}
               </span>
             </div>
             <div className="flex justify-between">
               <span className="text-sm text-text-300">선호 가격대</span>
-              <span className="text-sm font-medium text-text-100">{summaryInfo.priceRange}</span>
+              <span className="text-sm font-medium text-text-100">
+                {summaryInfo.priceRange || '없음'}
+              </span>
             </div>
           </div>
         </div>

--- a/src/components/mypage/profile-edit/ProfileFormFields.tsx
+++ b/src/components/mypage/profile-edit/ProfileFormFields.tsx
@@ -76,7 +76,7 @@ export function ProfileFormFields({
             className={`${
               isNicknameChanged
                 ? FORM_STYLES.button.pinkOutline
-                : 'cursor-not-allowed bg-gray-100 text-gray-400'
+                : 'cursor-not-allowed bg-bg-200 text-text-300 text-sm font-medium'
             } h-12 min-w-[120px] rounded-lg`}
             onClick={onNicknameCheck}
           >

--- a/src/components/mypage/profile-edit/ProfileFormFields.tsx
+++ b/src/components/mypage/profile-edit/ProfileFormFields.tsx
@@ -22,6 +22,7 @@ interface ProfileFormFieldsProps {
   };
   nicknameGuide: string;
   nicknameGuideType: 'success' | 'error' | 'base';
+  isNicknameChanged: boolean;
   onNicknameChange: (value: string) => void;
   onNicknameCheck: () => void;
   onGenderChange: (value: string) => void;
@@ -39,6 +40,7 @@ export function ProfileFormFields({
   agreements,
   nicknameGuide,
   nicknameGuideType,
+  isNicknameChanged,
   onNicknameChange,
   onNicknameCheck,
   onGenderChange,
@@ -70,10 +72,15 @@ export function ProfileFormFields({
           />
           <button
             type="button"
-            className={FORM_STYLES.button.pinkOutline + ' h-12 min-w-[120px] rounded-lg'}
+            disabled={!isNicknameChanged}
+            className={`${
+              isNicknameChanged
+                ? FORM_STYLES.button.pinkOutline
+                : 'cursor-not-allowed bg-gray-100 text-gray-400'
+            } h-12 min-w-[120px] rounded-lg`}
             onClick={onNicknameCheck}
           >
-            중복 확인
+            {isNicknameChanged ? '중복 확인' : '변경 없음'}
           </button>
         </div>
       </FormField>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'bg-background/80 fixed inset-0 z-50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-muted-foreground text-sm', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,6 +3,15 @@ export { Badge, badgeVariants } from './badge';
 export { Button, buttonVariants } from './button';
 export { Calendar, CalendarDayButton } from './calendar';
 export { Card, CardContent } from './card';
+export {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
 export { Input } from './input';
 export {
   Select,

--- a/src/constants/beauty-profile.ts
+++ b/src/constants/beauty-profile.ts
@@ -10,9 +10,9 @@ export const SKIN_TYPE_OPTIONS = [
   { label: '건성', value: 'dry' },
   { label: '복합성', value: 'combination' },
   { label: '민감성', value: 'sensitive' },
-  { label: '약건성', value: 'slightly_dry' },
+  { label: '악건성', value: 'very_dry' },
   { label: '트러블성', value: 'trouble' },
-  { label: '중성', value: 'normal' },
+  { label: '중성', value: 'neutral' },
 ] as const;
 
 // 피부 톤 옵션

--- a/src/constants/beauty-profile.ts
+++ b/src/constants/beauty-profile.ts
@@ -6,24 +6,24 @@ export const BEAUTY_PROFILE_CONSTANTS = {
 
 // 피부 타입 옵션
 export const SKIN_TYPE_OPTIONS = [
-  { label: '지성', value: 'oily' },
-  { label: '건성', value: 'dry' },
-  { label: '복합성', value: 'combination' },
-  { label: '민감성', value: 'sensitive' },
-  { label: '악건성', value: 'very_dry' },
-  { label: '트러블성', value: 'trouble' },
-  { label: '중성', value: 'neutral' },
+  { label: '지성', value: 'OILY' },
+  { label: '건성', value: 'DRY' },
+  { label: '복합성', value: 'COMBINATION' },
+  { label: '민감성', value: 'SENSITIVE' },
+  { label: '악건성', value: 'VERY_DRY' },
+  { label: '트러블성', value: 'TROUBLE' },
+  { label: '중성', value: 'NEUTRAL' },
 ] as const;
 
 // 피부 톤 옵션
 export const SKIN_TONE_OPTIONS = [
-  { label: '쿨톤', value: 'cool' },
-  { label: '웜톤', value: 'warm' },
-  { label: '봄웜톤', value: 'spring_warm' },
-  { label: '여름쿨톤', value: 'summer_cool' },
-  { label: '가을웜톤', value: 'autumn_warm' },
-  { label: '겨울쿨톤', value: 'winter_cool' },
-  { label: '뉴트럴톤', value: 'neutral' },
+  { label: '쿨톤', value: 'COOL' },
+  { label: '웜톤', value: 'WARM' },
+  { label: '봄웜톤', value: 'SPRING_WARM' },
+  { label: '여름쿨톤', value: 'SUMMER_COOL' },
+  { label: '가을웜톤', value: 'AUTUMN_WARM' },
+  { label: '겨울쿨톤', value: 'WINTER_COOL' },
+  { label: '뉴트럴톤', value: 'NEUTRAL' },
 ] as const;
 
 // 피부 고민 옵션

--- a/src/constants/form-styles.ts
+++ b/src/constants/form-styles.ts
@@ -35,6 +35,9 @@ export const FORM_STYLES = {
       selected: 'border-primary-300 bg-primary-100 text-primary-300',
       unselected: 'border-bg-300 bg-bg-100 text-text-300 hover:bg-bg-200',
     },
+    // 다이얼로그 버튼 스타일
+    dialog:
+      'border border-primary-300 bg-primary-300 text-text-on text-sm font-medium hover:opacity-80 transition-opacity shadow-none',
   },
 
   // 헬퍼 텍스트 스타일

--- a/src/hooks/useBeautyProfileEdit.ts
+++ b/src/hooks/useBeautyProfileEdit.ts
@@ -107,6 +107,24 @@ export const useBeautyProfileEdit = () => {
           }
         }
 
+        // 가격 입력 시 자동 정렬
+        if (field === 'minPrice' || field === 'maxPrice') {
+          const newData = { ...prev, [field]: value };
+          const minPrice = field === 'minPrice' ? Number(value) : Number(prev.minPrice);
+          const maxPrice = field === 'maxPrice' ? Number(value) : Number(prev.maxPrice);
+
+          // 두 가격이 모두 입력되었고, 최소가격이 최대가격보다 큰 경우 자동 정렬
+          if (minPrice > 0 && maxPrice > 0 && minPrice > maxPrice) {
+            return {
+              ...newData,
+              minPrice: maxPrice.toString(),
+              maxPrice: minPrice.toString(),
+            };
+          }
+
+          return newData;
+        }
+
         // allergyInput만 별도로 처리
         if (field === 'allergyInput') {
           return { ...prev, allergyInput: value as string };
@@ -164,24 +182,8 @@ export const useBeautyProfileEdit = () => {
       e.preventDefault();
 
       // 가격 범위 검증
-      let minPrice = Number(beautyProfileData.minPrice) || 0;
-      let maxPrice = Number(beautyProfileData.maxPrice) || 0;
-
-      // 최소가격이 최대가격보다 큰 경우 자동으로 값 교체
-      let priceSwapped = false;
-      if (minPrice > maxPrice && maxPrice > 0) {
-        const temp = minPrice;
-        minPrice = maxPrice;
-        maxPrice = temp;
-        priceSwapped = true;
-
-        // 상태도 업데이트
-        setBeautyProfileData((prev) => ({
-          ...prev,
-          minPrice: minPrice.toString(),
-          maxPrice: maxPrice.toString(),
-        }));
-      }
+      const minPrice = Number(beautyProfileData.minPrice) || 0;
+      const maxPrice = Number(beautyProfileData.maxPrice) || 0;
 
       if (minPrice >= 2147483640 || maxPrice >= 2147483640) {
         setErrorDialog({
@@ -227,9 +229,7 @@ export const useBeautyProfileEdit = () => {
         setSuccessDialog({
           isOpen: true,
           title: '뷰티프로필 수정 완료',
-          message: priceSwapped
-            ? '뷰티프로필이 성공적으로 수정되었습니다. (최소/최대 가격이 자동으로 조정되었습니다)'
-            : '뷰티프로필이 성공적으로 수정되었습니다.',
+          message: '뷰티프로필이 성공적으로 수정되었습니다.',
         });
       } catch (error: any) {
         console.error('뷰티프로필 수정 실패:', error);

--- a/src/hooks/useBeautyProfileEdit.ts
+++ b/src/hooks/useBeautyProfileEdit.ts
@@ -11,7 +11,7 @@ import {
 } from '@/constants/beauty-profile';
 
 const INITIAL_BEAUTY_PROFILE_DATA: BeautyProfileFormData = {
-  skinType: 'normal',
+  skinType: 'neutral',
   skinTone: 'neutral',
   skinConcerns: ['none'],
   skinReaction: 'no',

--- a/src/hooks/useBeautyProfileEdit.ts
+++ b/src/hooks/useBeautyProfileEdit.ts
@@ -269,7 +269,7 @@ export const useBeautyProfileEdit = () => {
         });
       }
     },
-    [beautyProfileData, router],
+    [beautyProfileData],
   );
 
   const closeErrorDialog = useCallback(() => {

--- a/src/hooks/useBeautyProfileEdit.ts
+++ b/src/hooks/useBeautyProfileEdit.ts
@@ -31,33 +31,10 @@ export const useBeautyProfileEdit = () => {
 
   const handleInputChange = useCallback(
     (field: keyof BeautyProfileFormData, value: string | string[]) => {
-      setBeautyProfileData((prev) => {
-        const newData = {
-          ...prev,
-          [field]: value,
-        };
-
-        // 가격 입력 시 최소값과 최대값 자동 정렬
-        if ((field === 'minPrice' || field === 'maxPrice') && typeof value === 'string') {
-          const minPrice = field === 'minPrice' ? value : prev.minPrice;
-          const maxPrice = field === 'maxPrice' ? value : prev.maxPrice;
-
-          if (minPrice && maxPrice) {
-            const minNum = Number(minPrice);
-            const maxNum = Number(maxPrice);
-
-            if (!isNaN(minNum) && !isNaN(maxNum)) {
-              if (minNum > maxNum) {
-                // 최소값이 최대값보다 크면 자동으로 교체
-                newData.minPrice = maxPrice;
-                newData.maxPrice = minPrice;
-              }
-            }
-          }
-        }
-
-        return newData;
-      });
+      setBeautyProfileData((prev) => ({
+        ...prev,
+        [field]: value,
+      }));
     },
     [],
   );
@@ -108,18 +85,22 @@ export const useBeautyProfileEdit = () => {
     async (e: React.FormEvent) => {
       e.preventDefault();
       try {
+        // 알러지 입력값: skinReaction이 'no'가 아니면 productRequest 필드(알러지 입력란)에서 공백으로 split
+        const allergies =
+          beautyProfileData.skinReaction !== 'no' && beautyProfileData.productRequest
+            ? beautyProfileData.productRequest.split(' ').filter(Boolean)
+            : [];
         // 폼 데이터를 API 요청 형식에 맞게 변환
         const payload = {
           skinType: beautyProfileData.skinType,
           skinTone: beautyProfileData.skinTone,
           concerns: beautyProfileData.skinConcerns.filter((c) => c !== 'none'),
           hasAllergy: beautyProfileData.skinReaction !== 'no',
-          allergies:
-            beautyProfileData.skinReaction !== 'no' ? [beautyProfileData.skinReaction] : [],
+          allergies,
           interestCategories: beautyProfileData.interestCategories.filter((c) => c !== 'none'),
           minPrice: Number(beautyProfileData.minPrice) || 0,
           maxPrice: Number(beautyProfileData.maxPrice) || 0,
-          additionalInfo: beautyProfileData.productRequest || '',
+          additionalInfo: '',
         };
         await updateBeautyProfile(payload);
         router.push('/mypage');

--- a/src/hooks/useBeautyProfileEdit.ts
+++ b/src/hooks/useBeautyProfileEdit.ts
@@ -164,17 +164,23 @@ export const useBeautyProfileEdit = () => {
       e.preventDefault();
 
       // 가격 범위 검증
-      const minPrice = Number(beautyProfileData.minPrice) || 0;
-      const maxPrice = Number(beautyProfileData.maxPrice) || 0;
+      let minPrice = Number(beautyProfileData.minPrice) || 0;
+      let maxPrice = Number(beautyProfileData.maxPrice) || 0;
 
+      // 최소가격이 최대가격보다 큰 경우 자동으로 값 교체
+      let priceSwapped = false;
       if (minPrice > maxPrice && maxPrice > 0) {
-        setErrorDialog({
-          isOpen: true,
-          title: '가격 범위 오류',
-          message: '최소 가격이 최대 가격보다 클 수 없습니다.',
-          errorDetails: '',
-        });
-        return;
+        const temp = minPrice;
+        minPrice = maxPrice;
+        maxPrice = temp;
+        priceSwapped = true;
+
+        // 상태도 업데이트
+        setBeautyProfileData((prev) => ({
+          ...prev,
+          minPrice: minPrice.toString(),
+          maxPrice: maxPrice.toString(),
+        }));
       }
 
       if (minPrice >= 2147483640 || maxPrice >= 2147483640) {
@@ -221,7 +227,9 @@ export const useBeautyProfileEdit = () => {
         setSuccessDialog({
           isOpen: true,
           title: '뷰티프로필 수정 완료',
-          message: '뷰티프로필이 성공적으로 수정되었습니다.',
+          message: priceSwapped
+            ? '뷰티프로필이 성공적으로 수정되었습니다. (최소/최대 가격이 자동으로 조정되었습니다)'
+            : '뷰티프로필이 성공적으로 수정되었습니다.',
         });
       } catch (error: any) {
         console.error('뷰티프로필 수정 실패:', error);

--- a/src/hooks/useBeautyProfileEdit.ts
+++ b/src/hooks/useBeautyProfileEdit.ts
@@ -9,6 +9,7 @@ import {
   INTEREST_CATEGORY_OPTIONS,
   BEAUTY_PROFILE_CONSTANTS,
 } from '@/constants/beauty-profile';
+import { updateBeautyProfile } from '@/services/beautyProfileService';
 
 const INITIAL_BEAUTY_PROFILE_DATA: BeautyProfileFormData = {
   skinType: 'neutral',
@@ -104,12 +105,27 @@ export const useBeautyProfileEdit = () => {
   }, []);
 
   const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
+    async (e: React.FormEvent) => {
       e.preventDefault();
-      // TODO: 실제 뷰티프로필 저장 API 연동 필요
-      // TODO: 실제 뷰티프로필 저장 API 호출
-      // 저장 후 마이페이지로 이동
-      router.push('/mypage');
+      try {
+        // 폼 데이터를 API 요청 형식에 맞게 변환
+        const payload = {
+          skinType: beautyProfileData.skinType,
+          skinTone: beautyProfileData.skinTone,
+          concerns: beautyProfileData.skinConcerns.filter((c) => c !== 'none'),
+          hasAllergy: beautyProfileData.skinReaction !== 'no',
+          allergies:
+            beautyProfileData.skinReaction !== 'no' ? [beautyProfileData.skinReaction] : [],
+          interestCategories: beautyProfileData.interestCategories.filter((c) => c !== 'none'),
+          minPrice: Number(beautyProfileData.minPrice) || 0,
+          maxPrice: Number(beautyProfileData.maxPrice) || 0,
+          additionalInfo: beautyProfileData.productRequest || '',
+        };
+        await updateBeautyProfile(payload);
+        router.push('/mypage');
+      } catch (error) {
+        alert('뷰티프로필 수정에 실패했습니다.');
+      }
     },
     [beautyProfileData, router],
   );

--- a/src/hooks/useProfileEdit.ts
+++ b/src/hooks/useProfileEdit.ts
@@ -28,7 +28,9 @@ export const useProfileEdit = () => {
 
         // 기존 프로필 정보로 초기값 설정
         setNickname(profileData.nickname || '');
-        setGender(profileData.gender || '');
+        console.log('API에서 받은 성별 값:', profileData.gender);
+        // API에서 받은 성별 값을 소문자로 변환 (FEMALE → female)
+        setGender(profileData.gender ? profileData.gender.toLowerCase() : '');
         setPhone(profileData.phone || '');
         setProfileImg(profileData.profile_image || '/profile-image.svg');
 
@@ -100,10 +102,13 @@ export const useProfileEdit = () => {
       }
 
       try {
+        // 성별 값을 API 형식으로 변환 (소문자 → 대문자)
+        const apiGender = gender ? gender.toUpperCase() : '';
+
         // 프로필 수정 API 요청
         const payload: any = {
           nickname: nickname.trim(),
-          gender,
+          gender: apiGender,
           phone: phone.trim(),
         };
 

--- a/src/hooks/useProfileEdit.ts
+++ b/src/hooks/useProfileEdit.ts
@@ -9,6 +9,7 @@ export const useProfileEdit = () => {
   const router = useSafeRouter();
 
   const [nickname, setNickname] = useState('');
+  const [originalNickname, setOriginalNickname] = useState(''); // 기존 닉네임 저장
   const [gender, setGender] = useState('');
   const [birth, setBirth] = useState<Date | undefined>(undefined);
   const [phone, setPhone] = useState('');
@@ -43,6 +44,7 @@ export const useProfileEdit = () => {
 
         // 기존 프로필 정보로 초기값 설정
         setNickname(profileData.nickname || '');
+        setOriginalNickname(profileData.nickname || ''); // 기존 닉네임 저장
         console.log('API에서 받은 성별 값:', profileData.gender);
         // API에서 받은 성별 값을 소문자로 변환 (FEMALE → female)
         setGender(profileData.gender ? profileData.gender.toLowerCase() : '');
@@ -106,19 +108,26 @@ export const useProfileEdit = () => {
     setAgreements((prev) => ({ ...prev, [field]: checked }));
   }, []);
 
+  // 닉네임 변경 여부 감지
+  const isNicknameChanged = useCallback(() => {
+    return nickname.trim() !== originalNickname.trim();
+  }, [nickname, originalNickname]);
+
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
 
-      // 닉네임 중복 확인이 되지 않았거나 중복인 경우
-      if (!isNicknameChecked || nicknameGuideType === 'error') {
-        setErrorDialog({
-          isOpen: true,
-          title: '닉네임 확인 필요',
-          message: '닉네임 중복 확인을 완료해주세요.',
-          errorDetails: '',
-        });
-        return;
+      // 닉네임이 변경된 경우에만 중복 확인 검증
+      if (isNicknameChanged()) {
+        if (!isNicknameChecked || nicknameGuideType === 'error') {
+          setErrorDialog({
+            isOpen: true,
+            title: '닉네임 확인 필요',
+            message: '닉네임을 변경하셨습니다. 중복 확인을 완료해주세요.',
+            errorDetails: '',
+          });
+          return;
+        }
       }
 
       try {
@@ -171,7 +180,16 @@ export const useProfileEdit = () => {
         });
       }
     },
-    [nickname, gender, birth, phone, router, isNicknameChecked, nicknameGuideType],
+    [
+      nickname,
+      gender,
+      birth,
+      phone,
+      router,
+      isNicknameChecked,
+      nicknameGuideType,
+      isNicknameChanged,
+    ],
   );
 
   const closeErrorDialog = useCallback(() => {
@@ -186,6 +204,7 @@ export const useProfileEdit = () => {
   return {
     // 상태
     nickname,
+    originalNickname, // 기존 닉네임 상태 추가
     gender,
     birth,
     phone,
@@ -207,6 +226,7 @@ export const useProfileEdit = () => {
     handleSubmit,
     closeErrorDialog,
     closeSuccessDialog,
+    isNicknameChanged,
 
     // 상수
     GENDER_OPTIONS,

--- a/src/hooks/useProfileEdit.ts
+++ b/src/hooks/useProfileEdit.ts
@@ -3,7 +3,7 @@ import { useState, useCallback } from 'react';
 
 import { VALIDATION_CONSTANTS } from '@/constants/validation';
 import { GENDER_OPTIONS, DEFAULT_AGREEMENTS } from '@/constants/form-options';
-import { checkNicknameDuplicate } from '@/services/memberService';
+import { checkNicknameDuplicate, updateProfile } from '@/services/memberService';
 
 export const useProfileEdit = () => {
   const router = useSafeRouter();
@@ -55,14 +55,41 @@ export const useProfileEdit = () => {
   }, []);
 
   const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
+    async (e: React.FormEvent) => {
       e.preventDefault();
-      // TODO: 실제 프로필 수정 API 연동 필요
-      // TODO: 실제 프로필 수정 API 호출
-      // 수정 후 마이페이지로 이동
-      router.push('/mypage');
+
+      try {
+        // 닉네임 중복 확인
+        const isDuplicate = await checkNicknameDuplicate(nickname);
+        if (isDuplicate) {
+          alert('이미 사용 중인 닉네임입니다. 다른 닉네임을 사용해주세요.');
+          return;
+        }
+
+        // 프로필 수정 API 요청
+        const payload: any = {
+          nickname: nickname.trim(),
+          gender,
+          phone: phone.trim(),
+        };
+
+        // birth가 있을 때만 추가하고 간단한 날짜 형식으로 변환
+        if (birth) {
+          const year = birth.getFullYear();
+          const month = String(birth.getMonth() + 1).padStart(2, '0');
+          const day = String(birth.getDate()).padStart(2, '0');
+          payload.birth = `${year}-${month}-${day}`;
+        }
+
+        await updateProfile(payload);
+        alert('프로필이 성공적으로 수정되었습니다.');
+        router.push('/mypage');
+      } catch (error) {
+        console.error('프로필 수정 실패:', error);
+        alert('프로필 수정에 실패했습니다.');
+      }
     },
-    [router],
+    [nickname, gender, birth, phone, router],
   );
 
   return {

--- a/src/hooks/useProfileEdit.ts
+++ b/src/hooks/useProfileEdit.ts
@@ -3,6 +3,7 @@ import { useState, useCallback } from 'react';
 
 import { VALIDATION_CONSTANTS } from '@/constants/validation';
 import { GENDER_OPTIONS, DEFAULT_AGREEMENTS } from '@/constants/form-options';
+import { checkNicknameDuplicate } from '@/services/memberService';
 
 export const useProfileEdit = () => {
   const router = useSafeRouter();
@@ -16,15 +17,27 @@ export const useProfileEdit = () => {
   const [nicknameGuide, setNicknameGuide] = useState('');
   const [nicknameGuideType, setNicknameGuideType] = useState<'success' | 'error' | 'base'>('base');
 
-  const handleNicknameCheck = useCallback(() => {
+  const handleNicknameCheck = useCallback(async () => {
     if (!nickname.trim()) {
       setNicknameGuide('닉네임을 입력해주세요.');
       setNicknameGuideType('error');
       return;
     }
-    // TODO: 실제 중복확인 API 연동 필요
-    setNicknameGuide('사용 가능한 닉네임입니다.');
-    setNicknameGuideType('success');
+
+    try {
+      const isDuplicate = await checkNicknameDuplicate(nickname);
+      if (isDuplicate) {
+        setNicknameGuide('이미 사용 중인 닉네임입니다.');
+        setNicknameGuideType('error');
+      } else {
+        setNicknameGuide('사용 가능한 닉네임입니다.');
+        setNicknameGuideType('success');
+      }
+    } catch (error) {
+      console.error('닉네임 중복 확인 실패:', error);
+      setNicknameGuide('중복 확인 중 오류가 발생했습니다.');
+      setNicknameGuideType('error');
+    }
   }, [nickname]);
 
   const handleNicknameChange = useCallback((value: string) => {

--- a/src/hooks/useProfileEdit.ts
+++ b/src/hooks/useProfileEdit.ts
@@ -1,9 +1,9 @@
 import { useSafeRouter } from '@/hooks';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 import { VALIDATION_CONSTANTS } from '@/constants/validation';
 import { GENDER_OPTIONS, DEFAULT_AGREEMENTS } from '@/constants/form-options';
-import { checkNicknameDuplicate, updateProfile } from '@/services/memberService';
+import { checkNicknameDuplicate, updateProfile, getProfile } from '@/services/memberService';
 
 export const useProfileEdit = () => {
   const router = useSafeRouter();
@@ -13,10 +13,39 @@ export const useProfileEdit = () => {
   const [birth, setBirth] = useState<Date | undefined>(undefined);
   const [phone, setPhone] = useState('');
   const [agreements, setAgreements] = useState(DEFAULT_AGREEMENTS);
-  const [profileImg] = useState('/profile-image.svg');
+  const [profileImg, setProfileImg] = useState('/profile-image.svg');
   const [nicknameGuide, setNicknameGuide] = useState('');
   const [nicknameGuideType, setNicknameGuideType] = useState<'success' | 'error' | 'base'>('base');
   const [isNicknameChecked, setIsNicknameChecked] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  // 기존 프로필 정보 조회
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        setLoading(true);
+        const profileData = await getProfile();
+
+        // 기존 프로필 정보로 초기값 설정
+        setNickname(profileData.nickname || '');
+        setGender(profileData.gender || '');
+        setPhone(profileData.phone || '');
+        setProfileImg(profileData.profile_image || '/profile-image.svg');
+
+        // 생년월일이 있으면 Date 객체로 변환
+        if (profileData.birth) {
+          setBirth(new Date(profileData.birth));
+        }
+
+        setLoading(false);
+      } catch (error) {
+        console.error('프로필 정보 조회 실패:', error);
+        setLoading(false);
+      }
+    };
+
+    fetchProfile();
+  }, []);
 
   const handleNicknameCheck = useCallback(async () => {
     if (!nickname.trim()) {
@@ -107,6 +136,7 @@ export const useProfileEdit = () => {
     profileImg,
     nicknameGuide,
     nicknameGuideType,
+    loading,
 
     // 핸들러
     handleNicknameChange,

--- a/src/hooks/useProfileEdit.ts
+++ b/src/hooks/useProfileEdit.ts
@@ -16,11 +16,13 @@ export const useProfileEdit = () => {
   const [profileImg] = useState('/profile-image.svg');
   const [nicknameGuide, setNicknameGuide] = useState('');
   const [nicknameGuideType, setNicknameGuideType] = useState<'success' | 'error' | 'base'>('base');
+  const [isNicknameChecked, setIsNicknameChecked] = useState(false);
 
   const handleNicknameCheck = useCallback(async () => {
     if (!nickname.trim()) {
       setNicknameGuide('닉네임을 입력해주세요.');
       setNicknameGuideType('error');
+      setIsNicknameChecked(false);
       return;
     }
 
@@ -29,14 +31,17 @@ export const useProfileEdit = () => {
       if (isDuplicate) {
         setNicknameGuide('이미 사용 중인 닉네임입니다.');
         setNicknameGuideType('error');
+        setIsNicknameChecked(false);
       } else {
         setNicknameGuide('사용 가능한 닉네임입니다.');
         setNicknameGuideType('success');
+        setIsNicknameChecked(true);
       }
     } catch (error) {
       console.error('닉네임 중복 확인 실패:', error);
       setNicknameGuide('중복 확인 중 오류가 발생했습니다.');
       setNicknameGuideType('error');
+      setIsNicknameChecked(false);
     }
   }, [nickname]);
 
@@ -44,6 +49,7 @@ export const useProfileEdit = () => {
     setNickname(value);
     setNicknameGuide('');
     setNicknameGuideType('base');
+    setIsNicknameChecked(false);
   }, []);
 
   const handlePhoneChange = useCallback((value: string) => {
@@ -58,14 +64,13 @@ export const useProfileEdit = () => {
     async (e: React.FormEvent) => {
       e.preventDefault();
 
-      try {
-        // 닉네임 중복 확인
-        const isDuplicate = await checkNicknameDuplicate(nickname);
-        if (isDuplicate) {
-          alert('이미 사용 중인 닉네임입니다. 다른 닉네임을 사용해주세요.');
-          return;
-        }
+      // 닉네임 중복 확인이 되지 않았거나 중복인 경우
+      if (!isNicknameChecked || nicknameGuideType === 'error') {
+        alert('닉네임 중복 확인을 해주세요.');
+        return;
+      }
 
+      try {
         // 프로필 수정 API 요청
         const payload: any = {
           nickname: nickname.trim(),
@@ -89,7 +94,7 @@ export const useProfileEdit = () => {
         alert('프로필 수정에 실패했습니다.');
       }
     },
-    [nickname, gender, birth, phone, router],
+    [nickname, gender, birth, phone, router, isNicknameChecked, nicknameGuideType],
   );
 
   return {

--- a/src/hooks/useProfileEdit.ts
+++ b/src/hooks/useProfileEdit.ts
@@ -180,16 +180,7 @@ export const useProfileEdit = () => {
         });
       }
     },
-    [
-      nickname,
-      gender,
-      birth,
-      phone,
-      router,
-      isNicknameChecked,
-      nicknameGuideType,
-      isNicknameChanged,
-    ],
+    [nickname, gender, birth, phone, isNicknameChecked, nicknameGuideType, isNicknameChanged],
   );
 
   const closeErrorDialog = useCallback(() => {

--- a/src/services/beautyProfileService.ts
+++ b/src/services/beautyProfileService.ts
@@ -1,0 +1,18 @@
+import api from '@/lib/axios';
+
+export interface BeautyProfileRequest {
+  skinType: string;
+  skinTone: string;
+  concerns: string[];
+  hasAllergy: boolean;
+  allergies: string[];
+  interestCategories: string[];
+  minPrice: number;
+  maxPrice: number;
+  additionalInfo: string;
+}
+
+export async function updateBeautyProfile(data: BeautyProfileRequest) {
+  const response = await api.patch('/members/beauty-profile', data);
+  return response.data;
+}

--- a/src/services/beautyProfileService.ts
+++ b/src/services/beautyProfileService.ts
@@ -12,7 +12,28 @@ export interface BeautyProfileRequest {
   additionalInfo: string;
 }
 
+export interface BeautyProfileResponse {
+  id: number;
+  member_id: number;
+  skin_type: string;
+  skin_tone: string;
+  concerns: string[];
+  has_allergy: boolean;
+  allergies: string[];
+  interest_categories: string[];
+  min_price: number;
+  max_price: number;
+  additional_info: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export async function updateBeautyProfile(data: BeautyProfileRequest) {
   const response = await api.patch('/members/beauty-profile', data);
   return response.data;
+}
+
+export async function getBeautyProfile() {
+  const response = await api.get('/members/beauty-profile');
+  return response.data.data;
 }

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -7,6 +7,21 @@ export interface UpdateProfileRequest {
   phone: string;
 }
 
+export interface ProfileResponse {
+  member_id: number;
+  email: string;
+  nickname: string;
+  profile_image: string | null;
+  user_type: 'MEMBER' | 'SELLER';
+  member_name: string;
+  points: number;
+  skin_type: string;
+  skin_tone: string;
+  gender?: string;
+  birth?: string;
+  phone?: string;
+}
+
 export async function checkNicknameDuplicate(nickname: string): Promise<boolean> {
   // 한국어 닉네임을 고려하여 URL 인코딩
   const encodedNickname = encodeURIComponent(nickname);
@@ -18,4 +33,9 @@ export async function checkNicknameDuplicate(nickname: string): Promise<boolean>
 export async function updateProfile(data: UpdateProfileRequest) {
   const response = await api.patch('/members/me', data);
   return response.data;
+}
+
+export async function getProfile() {
+  const response = await api.get('/members/me');
+  return response.data.data;
 }

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -1,9 +1,21 @@
 import api from '@/lib/axios';
 
+export interface UpdateProfileRequest {
+  nickname: string;
+  gender: string;
+  birth: string;
+  phone: string;
+}
+
 export async function checkNicknameDuplicate(nickname: string): Promise<boolean> {
   // 한국어 닉네임을 고려하여 URL 인코딩
   const encodedNickname = encodeURIComponent(nickname);
   const response = await api.get(`/members/nicknames/${encodedNickname}/exists`);
   // exists: true면 중복, false면 사용 가능
   return response.data.data.exists;
+}
+
+export async function updateProfile(data: UpdateProfileRequest) {
+  const response = await api.patch('/members/me', data);
+  return response.data;
 }

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -1,0 +1,9 @@
+import api from '@/lib/axios';
+
+export async function checkNicknameDuplicate(nickname: string): Promise<boolean> {
+  // 한국어 닉네임을 고려하여 URL 인코딩
+  const encodedNickname = encodeURIComponent(nickname);
+  const response = await api.get(`/members/nicknames/${encodedNickname}/exists`);
+  // exists: true면 중복, false면 사용 가능
+  return response.data.data.exists;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -6,6 +6,10 @@ export interface UserInfo {
   nickname: string;
   profile_image: string | null;
   user_type: 'MEMBER' | 'SELLER';
+  member_name: string;
+  points: number;
+  skin_type: string;
+  skin_tone: string;
 }
 
 export interface AuthResponse {

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -50,6 +50,7 @@ export interface BeautyProfileFormData {
   minPrice: string;
   maxPrice: string;
   productRequest: string;
+  allergyInput?: string; // 알러지 입력값
 }
 
 // 약관 동의 데이터 타입 정의


### PR DESCRIPTION
## ⭐️ Issue Number
- #64

## 🚩 Summary

### 마이페이지 부분 API 연동
- 내 정보 수정 - PUT /api/members/me
- 뷰티 프로필 작성 - POST /api/members/beauty-profile
- 뷰티 프로필 수정 - PUT /api/members/beauty-profile
- 마이페이지 조회 - GET /api/members/mypage
- 닉네임 중복 확인 - GET /api/members/nicknames/{nickname}/exists

## 🛠️ Technical Concerns
- CSS 수정하지 않도록 매번 확인했습니다! 아마 바뀐거 없을꺼에요.

## 🙂 To Reviewer
- [이번 백엔드 PR](https://github.com/UruruLab/Ururu-Backend/pull/157)으로 백엔드를 실행하셔야 제대로된 실행이 가능합니다!
- 추가될 로직은 없는지, 지금 로직이 이상하지 않은지 봐주시면 감사하겠십니다!

## 📋 To Do


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에서 사용자 맞춤 정보와 뷰티 프로필 데이터를 API를 통해 실시간으로 표시합니다.
  * 뷰티 프로필 수정 시 피부 반응에 따라 알러지 입력란이 동적으로 제공됩니다.
  * 닉네임 중복 확인 및 프로필 수정이 실제 서버와 연동되어 처리됩니다.
  * 프로필 편집 및 뷰티 프로필 수정 페이지에 로딩 상태와 성공/오류 다이얼로그가 추가되어 사용자 피드백이 강화되었습니다.
  * 오류 및 성공 메시지를 표시하는 공통 다이얼로그 컴포넌트가 도입되었습니다.

* **개선 및 변경**
  * 프로필 카드가 사용자 정보, 포인트, 피부 타입/톤을 더 정확하게 표시하며, 뱃지 표시 방식이 변경되었습니다.
  * 피부 타입/톤 옵션값이 대문자로 통일되고 일부 라벨이 수정되었습니다.
  * 뷰티 프로필 수정 시 가격 입력값의 최대 한도 제한과 검증 로직이 강화되었으며, 가격 자동 정렬 기능이 추가되었습니다.
  * 뷰티 프로필 요약 컴포넌트가 빈 값에 대해 기본 안내 문구를 표시하도록 개선되었습니다.
  * 닉네임 중복 확인 버튼이 닉네임 변경 여부에 따라 활성화 및 라벨이 변경되도록 개선되었습니다.

* **버그 수정**
  * 사용자 정보 표시 및 프로필 관련 입력값 처리의 안정성이 향상되었습니다.

* **기타**
  * 프로필 및 뷰티 프로필 관련 신규 API 서비스 모듈이 추가되어 서버와의 연동이 구현되었습니다.
  * 타입 정의가 확장되어 사용자 정보와 폼 데이터에 필요한 필드가 추가되었습니다.
  * UI 다이얼로그 컴포넌트가 새로 도입되어 일관된 모달 UI를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->