### PR TITLE
판매자 상품 등록 API 연동 및 상품 등록 페이지 이동 시 카테고리, 태그 정보 조회 API 연동

### DIFF
--- a/src/app/seller/products/new/page.tsx
+++ b/src/app/seller/products/new/page.tsx
@@ -1,18 +1,17 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-
+import { AuthGuard } from '@/components/auth/AuthGuard';
 import { ProductRegistration } from '@/components/seller/ProductRegistration';
 import { ProductService } from '@/services/productService';
 import type { Category, Tag } from '@/types/product';
 
-export default function NewProductPage() {
+// 인증된 사용자만 접근할 수 있는 상품 등록 컴포넌트
+function AuthenticatedProductRegistration() {
   const [categories, setCategories] = useState<Category[]>([]);
   const [tags, setTags] = useState<Tag[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const router = useRouter();
 
   useEffect(() => {
     const fetchMetadata = async () => {
@@ -23,20 +22,13 @@ export default function NewProductPage() {
         setCategories(data.categories);
         setTags(data.tags);
       } catch (err: any) {
-        if (
-          (typeof err.status === 'number' && err.status === 403) ||
-          (typeof err.message === 'string' && err.message.includes('status: 403'))
-        ) {
-          router.replace(`/login?redirect=/seller/products/new`);
-        } else {
-          setError(err.message || '상품 메타데이터 조회에 실패했습니다.');
-        }
+        setError(err.message || '상품 메타데이터 조회에 실패했습니다.');
       } finally {
         setIsLoading(false);
       }
     };
     fetchMetadata();
-  }, [router]);
+  }, []);
 
   if (isLoading) {
     return <div className="py-20 text-center text-gray-400">상품 등록 정보를 불러오는 중...</div>;
@@ -45,4 +37,12 @@ export default function NewProductPage() {
     return <div className="py-20 text-center text-red-500">{error}</div>;
   }
   return <ProductRegistration categories={categories} tags={tags} />;
+}
+
+export default function NewProductPage() {
+  return (
+    <AuthGuard requireAuth requireSeller>
+      <AuthenticatedProductRegistration />
+    </AuthGuard>
+  );
 }

--- a/src/app/seller/products/new/page.tsx
+++ b/src/app/seller/products/new/page.tsx
@@ -1,7 +1,48 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
 import { ProductRegistration } from '@/components/seller/ProductRegistration';
+import { ProductService } from '@/services/productService';
+import type { Category, Tag } from '@/types/product';
 
 export default function NewProductPage() {
-  return <ProductRegistration />;
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const fetchMetadata = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await ProductService.getProductMetadata();
+        setCategories(data.categories);
+        setTags(data.tags);
+      } catch (err: any) {
+        if (
+          (typeof err.status === 'number' && err.status === 403) ||
+          (typeof err.message === 'string' && err.message.includes('status: 403'))
+        ) {
+          router.replace(`/login?redirect=/seller/products/new`);
+        } else {
+          setError(err.message || '상품 메타데이터 조회에 실패했습니다.');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchMetadata();
+  }, [router]);
+
+  if (isLoading) {
+    return <div className="py-20 text-center text-gray-400">상품 등록 정보를 불러오는 중...</div>;
+  }
+  if (error) {
+    return <div className="py-20 text-center text-red-500">{error}</div>;
+  }
+  return <ProductRegistration categories={categories} tags={tags} />;
 }

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -592,9 +592,13 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
               <FormField label="내용물의 용량 또는 중량" required className="flex-1">
                 <Input
                   value={formData.capacity}
-                  onChange={(e) => handleInputChange('capacity', e.target.value)}
-                  placeholder=""
+                  onChange={(e) =>
+                    handleInputChange('capacity', e.target.value.replace(/[^0-9]/g, ''))
+                  }
+                  placeholder="예: 50, 100, 200 등 숫자만 입력"
                   className={FORM_STYLES.input.base}
+                  inputMode="numeric"
+                  pattern="[0-9]*"
                 />
               </FormField>
               <FormField label="단위" required className="w-32">

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -129,6 +129,106 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
     setSubmitError(null);
     setSubmitSuccess(false);
     try {
+      // 세분화된 필수 입력값 체크 및 메시지
+      if (!formData.categoryMain) {
+        setSubmitError('카테고리를 선택해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (selectedTags.length === 0) {
+        setSubmitError('태그를 1개 이상 선택해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.name) {
+        setSubmitError('상품명을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.description) {
+        setSubmitError('상품 설명을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (optionArray.items.length === 0) {
+        setSubmitError('상품 옵션을 1개 이상 추가해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      // 옵션별 필수 필드 검증
+      for (let i = 0; i < optionArray.items.length; i++) {
+        const option = optionArray.items[i];
+        if (!option.name) {
+          setSubmitError(`옵션 ${i + 1}의 옵션명을 입력해주세요.`);
+          setSubmitLoading(false);
+          return;
+        }
+        if (!option.price || option.price <= 0) {
+          setSubmitError(`옵션 ${i + 1}의 기본 가격을 입력해주세요.`);
+          setSubmitLoading(false);
+          return;
+        }
+        if (!option.stock) {
+          setSubmitError(`옵션 ${i + 1}의 전성분을 입력해주세요.`);
+          setSubmitLoading(false);
+          return;
+        }
+      }
+      if (!formData.capacity) {
+        setSubmitError('용량 또는 중량을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.specification) {
+        setSubmitError('제품 주요 사양을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.expiryDate) {
+        setSubmitError('사용기한(또는 개봉 후 사용기간)을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.usage) {
+        setSubmitError('사용법을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.manufacturer) {
+        setSubmitError('화장품제조업자를 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.seller) {
+        setSubmitError('화장품책임판매업자를 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.country) {
+        setSubmitError('제조국을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.functionalTest) {
+        setSubmitError('기능성 화장품 심사필 여부를 선택해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.precautions) {
+        setSubmitError('사용할 때의 주의사항을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.qualityStandard) {
+        setSubmitError('품질보증기준을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.customerService) {
+        setSubmitError('소비자상담 전화번호를 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
       // 카테고리 ID 배열 생성 (예시: 마지막 선택된 카테고리까지)
       const categoryIds: number[] = [];
       const findCategoryId = (label: string, cats: Category[]): number | null => {
@@ -350,7 +450,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 onChange={(e) => handleInputChange('name', e.target.value)}
                 placeholder="EX) 컬러그램 누디 블러 틴트 20 COLOR"
                 className={FORM_STYLES.input.base}
-                required
               />
             </FormField>
 
@@ -366,7 +465,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 className={FORM_STYLES.textarea.base}
                 rows={2}
                 maxLength={200}
-                required
               />
             </FormField>
 
@@ -606,7 +704,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                   onChange={(e) => handleInputChange('capacity', e.target.value)}
                   placeholder=""
                   className={FORM_STYLES.input.base}
-                  required
                 />
               </FormField>
               <FormField label="단위" required className="w-32">
@@ -637,7 +734,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 onChange={(e) => handleInputChange('specification', e.target.value)}
                 placeholder="EX) 모든 피부"
                 className={FORM_STYLES.input.base}
-                required
               />
             </FormField>
             <FormField label="사용기한(또는 개봉 후 사용기간)" required>
@@ -646,7 +742,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 onChange={(e) => handleInputChange('expiryDate', e.target.value)}
                 placeholder="EX) 제조일로부터 24개월"
                 className={FORM_STYLES.input.base}
-                required
               />
             </FormField>
             <FormField label="사용법" required>
@@ -656,7 +751,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 placeholder="EX) 적당량의 내용을 손에 덜어 얼굴에 부드럽게 펴 발라줍니다."
                 className={FORM_STYLES.textarea.base}
                 rows={2}
-                required
               />
             </FormField>
             <FormField label="화장품제조업자" required>
@@ -665,7 +759,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 onChange={(e) => handleInputChange('manufacturer', e.target.value)}
                 placeholder=""
                 className={FORM_STYLES.input.base}
-                required
               />
             </FormField>
             <FormField label="화장품책임판매업자" required>
@@ -674,7 +767,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 onChange={(e) => handleInputChange('seller', e.target.value)}
                 placeholder=""
                 className={FORM_STYLES.input.base}
-                required
               />
             </FormField>
             <FormField label="제조국" required>
@@ -683,7 +775,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 onChange={(e) => handleInputChange('country', e.target.value)}
                 placeholder="대한민국"
                 className={FORM_STYLES.input.base}
-                required
               />
             </FormField>
             <FormField label="기능성 화장품 식품의약품안전처 심사필 여부" required>
@@ -696,7 +787,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                     checked={formData.functionalTest === 'yes'}
                     onChange={(e) => handleInputChange('functionalTest', e.target.value)}
                     className="custom-radio"
-                    required
                   />
                   <span className="text-sm text-text-100">있음</span>
                 </label>
@@ -708,7 +798,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                     checked={formData.functionalTest === 'no'}
                     onChange={(e) => handleInputChange('functionalTest', e.target.value)}
                     className="custom-radio"
-                    required
                   />
                   <span className="text-sm text-text-100">없음</span>
                 </label>
@@ -721,7 +810,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 placeholder=""
                 className={FORM_STYLES.textarea.base}
                 rows={2}
-                required
               />
             </FormField>
             <FormField label="품질보증기준" required>
@@ -731,7 +819,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 placeholder="EX) 본 상품에 이상이 있을 경우 공정거래위원회 고시 '소비자분쟁 해결기준'에 의해 보상해 드립니다."
                 className={FORM_STYLES.textarea.base}
                 rows={2}
-                required
               />
             </FormField>
             <FormField label="소비자상담 전화번호" required>
@@ -740,7 +827,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 onChange={(e) => handleInputChange('customerService', e.target.value)}
                 placeholder="0000-0000"
                 className={FORM_STYLES.input.base}
-                required
               />
             </FormField>
           </div>

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -411,8 +411,8 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                           type="button"
                           className={`${FORM_STYLES.button.selectable.base} w-full ${
                             selectedTags.some((t) => t.value === tag.value)
-                              ? 'border-primary-300 bg-bg-100 text-primary-300'
-                              : 'border-bg-300 text-text-300 hover:bg-bg-300'
+                              ? 'border-primary-300 bg-primary-100 text-primary-300'
+                              : 'border-bg-300 text-text-300 hover:bg-bg-200'
                           }`}
                           aria-pressed={selectedTags.some((t) => t.value === tag.value)}
                           onClick={() => handleTagToggle(tag)}

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -409,23 +409,15 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                         <button
                           key={tag.value}
                           type="button"
-                          className={`h-10 w-full rounded-lg border px-2 text-xs font-medium transition-colors ${
+                          className={`${FORM_STYLES.button.selectable.base} h-10 w-full px-2 text-xs ${
                             selectedTags.some((t) => t.value === tag.value)
-                              ? 'border-primary-300 bg-bg-100 text-primary-300'
-                              : 'border-bg-300 text-text-300 hover:bg-bg-300'
-                          } `}
+                              ? FORM_STYLES.button.selectable.selected
+                              : FORM_STYLES.button.selectable.unselected
+                          }`}
                           aria-pressed={selectedTags.some((t) => t.value === tag.value)}
                           onClick={() => handleTagToggle(tag)}
                         >
-                          <span
-                            className={`block w-full truncate text-center ${
-                              selectedTags.some((t) => t.value === tag.value)
-                                ? 'text-primary-300'
-                                : 'text-text-300'
-                            }`}
-                          >
-                            {tag.label}
-                          </span>
+                          <span className="block w-full truncate text-center">{tag.label}</span>
                         </button>
                       ) : (
                         <div key={idx} />

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -17,7 +17,14 @@ import { PRODUCT_CATEGORY_DATA, CAPACITY_UNITS } from '@/data/seller';
 import { useFormArray } from '@/hooks/seller/useFormArray';
 import { OptionList } from './common/OptionList';
 import { SectionHeader } from '@/components/common/SectionHeader';
-import type { Category, Tag, CreateProductRequest } from '@/types/product';
+import type {
+  Category,
+  Tag,
+  CreateProductRequest,
+  ProductFormData,
+  ProductOption,
+  ProductRegistrationProps,
+} from '@/types/product';
 import { Badge } from '@/components/ui/badge';
 import { X } from 'lucide-react';
 import { useEffect } from 'react';
@@ -25,41 +32,7 @@ import { LoadingSkeleton } from '@/components/common/LoadingSkeleton';
 import { ProductService } from '@/services/productService';
 import { SuccessDialog } from '@/components/common/SuccessDialog';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
-
-interface ProductOption {
-  id: string;
-  name: string;
-  price: number;
-  image: File | null;
-  stock: number;
-}
-
-interface ProductFormData {
-  name: string;
-  description: string;
-  categoryMain: string;
-  categoryMiddle: string;
-  categorySub: string;
-  options: ProductOption[];
-  // 화장품 정보제공고시
-  capacity: string;
-  capacityUnit: string;
-  specification: string;
-  expiryDate: string;
-  usage: string;
-  manufacturer: string;
-  seller: string;
-  country: string;
-  functionalTest: 'yes' | 'no';
-  precautions: string;
-  qualityStandard: string;
-  customerService: string;
-}
-
-interface ProductRegistrationProps {
-  categories: Category[];
-  tags: Tag[];
-}
+import { validateProductForm } from '@/lib/product/validation';
 
 export function ProductRegistration({ categories, tags }: ProductRegistrationProps) {
   const [formData, setFormData] = useState<ProductFormData>({
@@ -129,103 +102,9 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
     setSubmitError(null);
     setSubmitSuccess(false);
     try {
-      // 세분화된 필수 입력값 체크 및 메시지 (폼 필드 순서대로)
-      if (!formData.name) {
-        setSubmitError('상품명을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.description) {
-        setSubmitError('상품 설명을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.categoryMain) {
-        setSubmitError('카테고리를 선택해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (selectedTags.length === 0) {
-        setSubmitError('태그를 1개 이상 선택해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (optionArray.items.length === 0) {
-        setSubmitError('상품 옵션을 1개 이상 추가해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      // 옵션별 필수 필드 검증
-      for (let i = 0; i < optionArray.items.length; i++) {
-        const option = optionArray.items[i];
-        if (!option.name) {
-          setSubmitError(`옵션 ${i + 1}의 옵션명을 입력해주세요.`);
-          setSubmitLoading(false);
-          return;
-        }
-        if (!option.price || option.price <= 0) {
-          setSubmitError(`옵션 ${i + 1}의 기본 가격을 입력해주세요.`);
-          setSubmitLoading(false);
-          return;
-        }
-        if (!option.stock) {
-          setSubmitError(`옵션 ${i + 1}의 전성분을 입력해주세요.`);
-          setSubmitLoading(false);
-          return;
-        }
-      }
-      if (!formData.capacity) {
-        setSubmitError('용량 또는 중량을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.specification) {
-        setSubmitError('제품 주요 사양을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.expiryDate) {
-        setSubmitError('사용기한(또는 개봉 후 사용기간)을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.usage) {
-        setSubmitError('사용법을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.manufacturer) {
-        setSubmitError('화장품제조업자를 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.seller) {
-        setSubmitError('화장품책임판매업자를 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.country) {
-        setSubmitError('제조국을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.functionalTest) {
-        setSubmitError('기능성 화장품 심사필 여부를 선택해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.precautions) {
-        setSubmitError('사용할 때의 주의사항을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.qualityStandard) {
-        setSubmitError('품질보증기준을 입력해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (!formData.customerService) {
-        setSubmitError('소비자상담 전화번호를 입력해주세요.');
+      const validationError = validateProductForm(formData, optionArray, selectedTags);
+      if (validationError) {
+        setSubmitError(validationError);
         setSubmitLoading(false);
         return;
       }

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -411,8 +411,8 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                           type="button"
                           className={`${FORM_STYLES.button.selectable.base} w-full ${
                             selectedTags.some((t) => t.value === tag.value)
-                              ? FORM_STYLES.button.selectable.selected
-                              : FORM_STYLES.button.selectable.unselected
+                              ? 'border-primary-300 bg-bg-100 text-primary-300'
+                              : 'border-bg-300 text-text-300 hover:bg-bg-300'
                           }`}
                           aria-pressed={selectedTags.some((t) => t.value === tag.value)}
                           onClick={() => handleTagToggle(tag)}

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -597,7 +597,12 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
             >
               <Input
                 value={formData.customerService}
-                onChange={(e) => handleInputChange('customerService', e.target.value)}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  // 숫자와 하이픈만 허용하는 정규식
+                  const filteredValue = value.replace(/[^0-9-]/g, '');
+                  handleInputChange('customerService', filteredValue);
+                }}
                 placeholder="0000-0000"
                 className={FORM_STYLES.input.base}
                 maxLength={13}

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -271,17 +271,18 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
   };
 
   // 카테고리 chip 텍스트 생성
-  const categoryChips = [
-    formData.categoryMain ? { label: formData.categoryMain } : null,
-    formData.categoryMiddle ? { label: formData.categoryMiddle } : null,
-    formData.categorySub ? { label: formData.categorySub } : null,
-  ].filter((chip): chip is { label: string } => Boolean(chip));
+  // const categoryChips = [
+  //   formData.categoryMain ? { label: formData.categoryMain } : null,
+  //   formData.categoryMiddle ? { label: formData.categoryMiddle } : null,
+  //   formData.categorySub ? { label: formData.categorySub } : null,
+  // ].filter((chip): chip is { label: string } => Boolean(chip));
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-10 md:px-0">
       {/* 타이틀 */}
       <h1 className="mb-10 text-center text-3xl font-semibold text-text-100">상품 등록</h1>
-      {/* 선택된 카테고리 chip */}
+      {/* 선택된 카테고리 chip (제거됨) */}
+      {/*
       {categoryChips.length > 0 && (
         <div className="mb-4 flex flex-wrap gap-2">
           {categoryChips.map((chip, i) => (
@@ -292,7 +293,9 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
           ))}
         </div>
       )}
-      {/* 선택된 태그 chip */}
+      */}
+      {/* 선택된 태그 chip (제거됨) */}
+      {/*
       {selectedTags.length > 0 && (
         <div className="mb-4 flex flex-wrap gap-2">
           {selectedTags.map((tag) => (
@@ -314,6 +317,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
           ))}
         </div>
       )}
+      */}
       <form onSubmit={handleSubmit} className="space-y-16">
         {/* 상품 기본 정보 */}
         <section>
@@ -427,7 +431,8 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                       </SelectContent>
                     </Select>
                   </div>
-                  {/* 선택된 카테고리 루트 경로 표시 및 제거 ( > 구분자 사용) */}
+                  {/* 선택된 카테고리 루트 경로 표시 및 제거 ( > 구분자 사용) (제거됨) */}
+                  {/*
                   {(formData.categoryMain || formData.categoryMiddle || formData.categorySub) && (
                     <div className="mt-2 flex items-center gap-2 text-sm text-gray-700">
                       <span>선택된 카테고리:</span>
@@ -475,6 +480,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                       )}
                     </div>
                   )}
+                  */}
                 </div>
               )}
             </FormField>
@@ -516,7 +522,8 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                       ),
                     )}
                   </div>
-                  {/* 선택된 태그 chip - 카테고리 chip과 동일한 형식으로 */}
+                  {/* 선택된 태그 chip - 카테고리 chip과 동일한 형식으로 (제거됨) */}
+                  {/*
                   {selectedTags.length > 0 && (
                     <div className="mt-2 flex items-center gap-2 text-sm text-gray-700">
                       <span>선택된 태그:</span>
@@ -538,6 +545,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                       ))}
                     </div>
                   )}
+                  */}
                 </div>
               )}
             </FormField>

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -712,12 +712,17 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                 rows={2}
               />
             </FormField>
-            <FormField label="소비자상담 전화번호" required>
+            <FormField
+              label="소비자상담 전화번호"
+              required
+              helperText="번호는 하이픈(-)을 포함해서 입력해주세요. 예: 0000-0000"
+            >
               <Input
                 value={formData.customerService}
                 onChange={(e) => handleInputChange('customerService', e.target.value)}
                 placeholder="0000-0000"
                 className={FORM_STYLES.input.base}
+                maxLength={13}
               />
             </FormField>
           </div>

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -503,16 +503,20 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                         <button
                           key={tag.value}
                           type="button"
-                          className={`h-10 w-full rounded-full border px-2 text-xs font-medium transition-colors ${
+                          className={`h-10 w-full rounded-lg border px-2 text-xs font-medium transition-colors ${
                             selectedTags.some((t) => t.value === tag.value)
                               ? 'border-primary-100 bg-primary-100 text-primary-300 shadow-md'
-                              : 'border-bg-300 bg-bg-100 text-text-100 hover:bg-primary-100 hover:text-primary-300'
+                              : 'border-bg-300 bg-bg-100 text-text-100 hover:bg-bg-200 hover:text-primary-300'
                           } `}
                           aria-pressed={selectedTags.some((t) => t.value === tag.value)}
                           onClick={() => handleTagToggle(tag)}
                         >
                           <span
-                            className={`block w-full truncate text-center ${selectedTags.some((t) => t.value === tag.value) ? 'text-primary-300' : 'text-text-100'}`}
+                            className={`block w-full truncate text-center ${
+                              selectedTags.some((t) => t.value === tag.value)
+                                ? 'text-primary-300'
+                                : 'text-text-100'
+                            }`}
                           >
                             {tag.label}
                           </span>

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -270,54 +270,10 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
     setSelectedTags((prev) => prev.filter((t) => t.value !== tag.value));
   };
 
-  // 카테고리 chip 텍스트 생성
-  // const categoryChips = [
-  //   formData.categoryMain ? { label: formData.categoryMain } : null,
-  //   formData.categoryMiddle ? { label: formData.categoryMiddle } : null,
-  //   formData.categorySub ? { label: formData.categorySub } : null,
-  // ].filter((chip): chip is { label: string } => Boolean(chip));
-
   return (
     <div className="mx-auto max-w-3xl px-4 py-10 md:px-0">
       {/* 타이틀 */}
       <h1 className="mb-10 text-center text-3xl font-semibold text-text-100">상품 등록</h1>
-      {/* 선택된 카테고리 chip (제거됨) */}
-      {/*
-      {categoryChips.length > 0 && (
-        <div className="mb-4 flex flex-wrap gap-2">
-          {categoryChips.map((chip, i) => (
-            <Badge key={chip.label} variant="default" className="bg-primary text-white">
-              {chip.label}
-              {i < categoryChips.length - 1 && <span className="mx-1">&gt;</span>}
-            </Badge>
-          ))}
-        </div>
-      )}
-      */}
-      {/* 선택된 태그 chip (제거됨) */}
-      {/*
-      {selectedTags.length > 0 && (
-        <div className="mb-4 flex flex-wrap gap-2">
-          {selectedTags.map((tag) => (
-            <Badge
-              key={tag.value}
-              variant="default"
-              className="bg-primary flex items-center gap-1 text-white"
-            >
-              {tag.label}
-              <button
-                type="button"
-                aria-label="태그 해제"
-                onClick={() => handleTagRemove(tag)}
-                className="ml-1 focus:outline-none"
-              >
-                <X size={14} />
-              </button>
-            </Badge>
-          ))}
-        </div>
-      )}
-      */}
       <form onSubmit={handleSubmit} className="space-y-16">
         {/* 상품 기본 정보 */}
         <section>
@@ -431,56 +387,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                       </SelectContent>
                     </Select>
                   </div>
-                  {/* 선택된 카테고리 루트 경로 표시 및 제거 ( > 구분자 사용) (제거됨) */}
-                  {/*
-                  {(formData.categoryMain || formData.categoryMiddle || formData.categorySub) && (
-                    <div className="mt-2 flex items-center gap-2 text-sm text-gray-700">
-                      <span>선택된 카테고리:</span>
-                      {formData.categoryMain && (
-                        <span className="flex items-center gap-1 rounded bg-gray-100 px-2 py-1">
-                          {formData.categoryMain}
-                          <button
-                            type="button"
-                            onClick={() => handleRemoveCategory('main')}
-                            className="ml-1"
-                          >
-                            <X className="h-3 w-3" />
-                          </button>
-                        </span>
-                      )}
-                      {formData.categoryMiddle && (
-                        <>
-                          <span className="mx-1">&gt;</span>
-                          <span className="flex items-center gap-1 rounded bg-gray-100 px-2 py-1">
-                            {formData.categoryMiddle}
-                            <button
-                              type="button"
-                              onClick={() => handleRemoveCategory('middle')}
-                              className="ml-1"
-                            >
-                              <X className="h-3 w-3" />
-                            </button>
-                          </span>
-                        </>
-                      )}
-                      {formData.categorySub && (
-                        <>
-                          <span className="mx-1">&gt;</span>
-                          <span className="flex items-center gap-1 rounded bg-gray-100 px-2 py-1">
-                            {formData.categorySub}
-                            <button
-                              type="button"
-                              onClick={() => handleRemoveCategory('sub')}
-                              className="ml-1"
-                            >
-                              <X className="h-3 w-3" />
-                            </button>
-                          </span>
-                        </>
-                      )}
-                    </div>
-                  )}
-                  */}
                 </div>
               )}
             </FormField>
@@ -505,8 +411,8 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                           type="button"
                           className={`h-10 w-full rounded-lg border px-2 text-xs font-medium transition-colors ${
                             selectedTags.some((t) => t.value === tag.value)
-                              ? 'border-primary-100 bg-primary-100 text-primary-300 shadow-md'
-                              : 'border-bg-300 bg-bg-100 text-text-100 hover:bg-bg-200 hover:text-primary-300'
+                              ? 'border-primary-300 bg-bg-100 text-primary-300'
+                              : 'border-bg-300 text-text-300 hover:bg-bg-300'
                           } `}
                           aria-pressed={selectedTags.some((t) => t.value === tag.value)}
                           onClick={() => handleTagToggle(tag)}
@@ -515,7 +421,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                             className={`block w-full truncate text-center ${
                               selectedTags.some((t) => t.value === tag.value)
                                 ? 'text-primary-300'
-                                : 'text-text-100'
+                                : 'text-text-300'
                             }`}
                           >
                             {tag.label}
@@ -526,30 +432,6 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                       ),
                     )}
                   </div>
-                  {/* 선택된 태그 chip - 카테고리 chip과 동일한 형식으로 (제거됨) */}
-                  {/*
-                  {selectedTags.length > 0 && (
-                    <div className="mt-2 flex items-center gap-2 text-sm text-gray-700">
-                      <span>선택된 태그:</span>
-                      {selectedTags.map((tag, i) => (
-                        <span
-                          key={tag.value}
-                          className="flex items-center gap-1 rounded bg-gray-100 px-2 py-1"
-                        >
-                          {tag.label}
-                          <button
-                            type="button"
-                            aria-label="태그 해제"
-                            onClick={() => handleTagRemove(tag)}
-                            className="ml-1 focus:outline-none"
-                          >
-                            <X className="h-3 w-3" />
-                          </button>
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                  */}
                 </div>
               )}
             </FormField>

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -23,6 +23,8 @@ import { X } from 'lucide-react';
 import { useEffect } from 'react';
 import { LoadingSkeleton } from '@/components/common/LoadingSkeleton';
 import { ProductService } from '@/services/productService';
+import { SuccessDialog } from '@/components/common/SuccessDialog';
+import { ErrorDialog } from '@/components/common/ErrorDialog';
 
 interface ProductOption {
   id: string;
@@ -118,6 +120,8 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
   const [submitLoading, setSubmitLoading] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState(false);
+  const handleSuccessDialogClose = () => setSubmitSuccess(false);
+  const handleErrorDialogClose = () => setSubmitError(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -751,14 +755,18 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
           >
             {submitLoading ? '등록 중...' : '등록하기'}
           </Button>
-          {submitError && (
-            <div className="mt-2 text-center text-sm text-red-500">{submitError}</div>
-          )}
-          {submitSuccess && (
-            <div className="mt-2 text-center text-sm text-green-600">
-              상품이 성공적으로 등록되었습니다.
-            </div>
-          )}
+          <ErrorDialog
+            isOpen={!!submitError}
+            onClose={handleErrorDialogClose}
+            title="상품 등록 실패"
+            message={submitError || ''}
+          />
+          <SuccessDialog
+            isOpen={submitSuccess}
+            onClose={handleSuccessDialogClose}
+            title="상품 등록 완료"
+            message="상품이 성공적으로 등록되었습니다."
+          />
         </div>
       </form>
     </div>

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -17,7 +17,7 @@ import { PRODUCT_CATEGORY_DATA, CAPACITY_UNITS } from '@/data/seller';
 import { useFormArray } from '@/hooks/seller/useFormArray';
 import { OptionList } from './common/OptionList';
 import { SectionHeader } from '@/components/common/SectionHeader';
-import type { Category, Tag } from '@/types/product';
+import type { Category, Tag, CreateProductRequest } from '@/types/product';
 import { Badge } from '@/components/ui/badge';
 import { X } from 'lucide-react';
 import { useEffect } from 'react';
@@ -266,7 +266,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
       const productOptions = optionArray.items.map((opt) => ({
         name: opt.name,
         price: opt.price,
-        fullIngredients: opt.stock,
+        fullIngredients: String(opt.stock),
       }));
       // 옵션 이미지
       const optionImages = optionArray.items
@@ -286,7 +286,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
         warranty: formData.qualityStandard,
         customerServiceNumber: formData.customerService,
       };
-      const product = {
+      const product: CreateProductRequest = {
         name: formData.name,
         description: formData.description,
         categoryIds,

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -129,17 +129,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
     setSubmitError(null);
     setSubmitSuccess(false);
     try {
-      // 세분화된 필수 입력값 체크 및 메시지
-      if (!formData.categoryMain) {
-        setSubmitError('카테고리를 선택해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
-      if (selectedTags.length === 0) {
-        setSubmitError('태그를 1개 이상 선택해주세요.');
-        setSubmitLoading(false);
-        return;
-      }
+      // 세분화된 필수 입력값 체크 및 메시지 (폼 필드 순서대로)
       if (!formData.name) {
         setSubmitError('상품명을 입력해주세요.');
         setSubmitLoading(false);
@@ -147,6 +137,16 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
       }
       if (!formData.description) {
         setSubmitError('상품 설명을 입력해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (!formData.categoryMain) {
+        setSubmitError('카테고리를 선택해주세요.');
+        setSubmitLoading(false);
+        return;
+      }
+      if (selectedTags.length === 0) {
+        setSubmitError('태그를 1개 이상 선택해주세요.');
         setSubmitLoading(false);
         return;
       }

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -86,7 +86,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
       name: '',
       price: 0,
       image: null,
-      stock: 0,
+      fullIngredients: '',
     });
   };
 
@@ -145,7 +145,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
       const productOptions = optionArray.items.map((opt) => ({
         name: opt.name,
         price: opt.price,
-        fullIngredients: String(opt.stock),
+        fullIngredients: opt.fullIngredients,
       }));
       // 옵션 이미지
       const optionImages = optionArray.items

--- a/src/components/seller/ProductRegistration.tsx
+++ b/src/components/seller/ProductRegistration.tsx
@@ -409,7 +409,7 @@ export function ProductRegistration({ categories, tags }: ProductRegistrationPro
                         <button
                           key={tag.value}
                           type="button"
-                          className={`${FORM_STYLES.button.selectable.base} h-10 w-full px-2 text-xs ${
+                          className={`${FORM_STYLES.button.selectable.base} w-full ${
                             selectedTags.some((t) => t.value === tag.value)
                               ? FORM_STYLES.button.selectable.selected
                               : FORM_STYLES.button.selectable.unselected

--- a/src/components/seller/common/ImageUploadField.tsx
+++ b/src/components/seller/common/ImageUploadField.tsx
@@ -38,7 +38,7 @@ export function ImageUploadField({
       >
         <input
           type="file"
-          accept={accept}
+          accept="image/png,image/jpeg,image/jpg"
           multiple={multiple}
           onChange={onUpload}
           className="hidden"

--- a/src/components/seller/common/OptionList.tsx
+++ b/src/components/seller/common/OptionList.tsx
@@ -11,7 +11,7 @@ interface Option {
   name: string;
   price: number;
   image: File | null;
-  stock: number;
+  fullIngredients: string;
 }
 
 interface OptionListProps {
@@ -104,8 +104,8 @@ function OptionCard({
             전성분 <span className={FORM_STYLES.label.required}>*</span>
           </label>
           <Input
-            value={option.stock || ''}
-            onChange={(e) => onChange(option.id, 'stock', e.target.value)}
+            value={option.fullIngredients || ''}
+            onChange={(e) => onChange(option.id, 'fullIngredients', e.target.value)}
             placeholder="전성분을 표기해주세요"
             className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
           />

--- a/src/components/seller/common/OptionList.tsx
+++ b/src/components/seller/common/OptionList.tsx
@@ -61,7 +61,6 @@ function OptionCard({
             onChange={(e) => onChange(option.id, 'name', e.target.value.slice(0, 20))}
             placeholder="EX) 07 킥로즈"
             maxLength={20}
-            required
             className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
           />
           <div className="mt-1 text-right text-xs text-text-300">
@@ -82,7 +81,6 @@ function OptionCard({
                 onChange(option.id, 'price', Number(value));
               }}
               placeholder="10,000"
-              required
               className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
             />
             <span className="absolute right-4 top-1/2 -translate-y-1/2 text-text-300">원</span>
@@ -109,7 +107,6 @@ function OptionCard({
             value={option.stock || ''}
             onChange={(e) => onChange(option.id, 'stock', e.target.value)}
             placeholder="전성분을 표기해주세요"
-            required
             className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
           />
         </div>

--- a/src/lib/product/validation.ts
+++ b/src/lib/product/validation.ts
@@ -1,0 +1,31 @@
+import type { ProductFormData, ProductOption, Tag } from '@/types/product';
+
+export function validateProductForm(
+  formData: ProductFormData,
+  optionArray: { items: ProductOption[] },
+  selectedTags: Tag[],
+): string | null {
+  if (!formData.name) return '상품명을 입력해주세요.';
+  if (!formData.description) return '상품 설명을 입력해주세요.';
+  if (!formData.categoryMain) return '카테고리를 선택해주세요.';
+  if (selectedTags.length === 0) return '태그를 1개 이상 선택해주세요.';
+  if (optionArray.items.length === 0) return '상품 옵션을 1개 이상 추가해주세요.';
+  for (let i = 0; i < optionArray.items.length; i++) {
+    const option = optionArray.items[i];
+    if (!option.name) return `옵션 ${i + 1}의 옵션명을 입력해주세요.`;
+    if (!option.price || option.price <= 0) return `옵션 ${i + 1}의 기본 가격을 입력해주세요.`;
+    if (!option.stock) return `옵션 ${i + 1}의 전성분을 입력해주세요.`;
+  }
+  if (!formData.capacity) return '용량 또는 중량을 입력해주세요.';
+  if (!formData.specification) return '제품 주요 사양을 입력해주세요.';
+  if (!formData.expiryDate) return '사용기한(또는 개봉 후 사용기간)을 입력해주세요.';
+  if (!formData.usage) return '사용법을 입력해주세요.';
+  if (!formData.manufacturer) return '화장품제조업자를 입력해주세요.';
+  if (!formData.seller) return '화장품책임판매업자를 입력해주세요.';
+  if (!formData.country) return '제조국을 입력해주세요.';
+  if (!formData.functionalTest) return '기능성 화장품 심사필 여부를 선택해주세요.';
+  if (!formData.precautions) return '사용할 때의 주의사항을 입력해주세요.';
+  if (!formData.qualityStandard) return '품질보증기준을 입력해주세요.';
+  if (!formData.customerService) return '소비자상담 전화번호를 입력해주세요.';
+  return null;
+}

--- a/src/lib/product/validation.ts
+++ b/src/lib/product/validation.ts
@@ -14,7 +14,7 @@ export function validateProductForm(
     const option = optionArray.items[i];
     if (!option.name) return `옵션 ${i + 1}의 옵션명을 입력해주세요.`;
     if (!option.price || option.price <= 0) return `옵션 ${i + 1}의 기본 가격을 입력해주세요.`;
-    if (!option.stock) return `옵션 ${i + 1}의 전성분을 입력해주세요.`;
+    if (!option.fullIngredients) return `옵션 ${i + 1}의 전성분을 입력해주세요.`;
   }
   if (!formData.capacity) return '용량 또는 중량을 입력해주세요.';
   if (!formData.specification) return '제품 주요 사양을 입력해주세요.';

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -34,6 +34,9 @@ export class ProductService {
       formData.append('optionImages', file);
     });
     const response = await api.post('/products', formData);
-    return response.data;
+    if (!response.data.success) {
+      throw new Error(response.data.message || '상품 등록에 실패했습니다.');
+    }
+    return response.data.data;
   }
 }

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,0 +1,20 @@
+import api from '@/lib/axios';
+import type { ApiResponse } from '@/types/api';
+import type { ProductMetadataResponse } from '@/types/product';
+
+/**
+ * 상품 관련 서비스 (상품 등록 등)
+ */
+export class ProductService {
+  /**
+   * 상품 등록을 위한 메타데이터 조회 (카테고리, 태그 등)
+   * @returns {Promise<ProductMetadataResponse>}
+   */
+  static async getProductMetadata(): Promise<ProductMetadataResponse> {
+    const response = await api.get<ApiResponse<ProductMetadataResponse>>('/products/create');
+    if (!response.data.success) {
+      throw new Error(response.data.message || '상품 메타데이터 조회에 실패했습니다.');
+    }
+    return response.data.data!;
+  }
+}

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,6 +1,6 @@
 import api from '@/lib/axios';
 import type { ApiResponse } from '@/types/api';
-import type { ProductMetadataResponse } from '@/types/product';
+import type { ProductMetadataResponse, CreateProductRequest } from '@/types/product';
 
 /**
  * 상품 관련 서비스 (상품 등록 등)
@@ -26,7 +26,7 @@ export class ProductService {
    * @param product 상품 정보(JSON 직렬화)
    * @param optionImages 옵션 이미지 파일 배열
    */
-  static async createProduct(product: object, optionImages: File[]): Promise<any> {
+  static async createProduct(product: CreateProductRequest, optionImages: File[]): Promise<any> {
     const formData = new FormData();
     // Content-Type 명시적으로 지정
     formData.append('product', new Blob([JSON.stringify(product)], { type: 'application/json' }));

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -17,4 +17,20 @@ export class ProductService {
     }
     return response.data.data!;
   }
+
+  /**
+   * 상품 등록
+   * @param product 상품 정보(JSON 직렬화)
+   * @param optionImages 옵션 이미지 파일 배열
+   */
+  static async createProduct(product: object, optionImages: File[]): Promise<any> {
+    const formData = new FormData();
+    // Content-Type 명시적으로 지정
+    formData.append('product', new Blob([JSON.stringify(product)], { type: 'application/json' }));
+    optionImages.forEach((file) => {
+      formData.append('optionImages', file);
+    });
+    const response = await api.post('/products', formData);
+    return response.data;
+  }
 }

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -15,7 +15,10 @@ export class ProductService {
     if (!response.data.success) {
       throw new Error(response.data.message || '상품 메타데이터 조회에 실패했습니다.');
     }
-    return response.data.data!;
+    if (!response.data.data) {
+      throw new Error('응답 데이터가 없습니다.');
+    }
+    return response.data.data;
   }
 
   /**

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -7,8 +7,11 @@ export interface SelectedOption {
 }
 
 export interface ProductOption {
-  label: string;
-  value: string;
+  id: string;
+  name: string;
+  price: number;
+  image: File | null;
+  stock: number;
 }
 
 export interface RewardTier {
@@ -86,4 +89,30 @@ export interface CreateProductRequest {
     fullIngredients: string;
   }>;
   productNotice: Record<string, any>;
+}
+
+export interface ProductFormData {
+  name: string;
+  description: string;
+  categoryMain: string;
+  categoryMiddle: string;
+  categorySub: string;
+  options: ProductOption[];
+  capacity: string;
+  capacityUnit: string;
+  specification: string;
+  expiryDate: string;
+  usage: string;
+  manufacturer: string;
+  seller: string;
+  country: string;
+  functionalTest: 'yes' | 'no';
+  precautions: string;
+  qualityStandard: string;
+  customerService: string;
+}
+
+export interface ProductRegistrationProps {
+  categories: Category[];
+  tags: Tag[];
 }

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -74,3 +74,16 @@ export const calculateDiscountRate = (originalPrice: number, currentPrice: numbe
   if (originalPrice <= 0) return 0;
   return Math.round(((originalPrice - currentPrice) / originalPrice) * 100);
 };
+
+export interface CreateProductRequest {
+  name: string;
+  description: string;
+  categoryIds: number[];
+  tagCategoryIds: number[];
+  productOptions: Array<{
+    name: string;
+    price: number;
+    fullIngredients: string;
+  }>;
+  productNotice: Record<string, any>;
+}

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -47,6 +47,22 @@ export interface Product {
   options: ProductOption[];
 }
 
+export interface Category {
+  value: number;
+  label: string;
+  children: Category[];
+}
+
+export interface Tag {
+  value: number;
+  label: string;
+}
+
+export interface ProductMetadataResponse {
+  categories: Category[];
+  tags: Tag[];
+}
+
 // 진행률 계산 유틸리티 함수
 export const calculateProgress = (participants: number, targetParticipants: number): number => {
   if (targetParticipants <= 0) return 0;

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -11,7 +11,7 @@ export interface ProductOption {
   name: string;
   price: number;
   image: File | null;
-  stock: number;
+  fullIngredients: string;
 }
 
 export interface RewardTier {


### PR DESCRIPTION
## ⭐️ Issue Number

- #74 

## 🚩 Summary
1. **ProductService 모듈화 및 타입 정의**
상품 메타데이터(카테고리, 태그) 조회 및 상품 등록 API를 담당하는 ProductService 생성
Category, Tag, ProductMetadataResponse 등 타입 정의 및 적용

2. **상품 등록 폼 UI/UX 개선**
카테고리: 3단계(대/중/소분류) 선택, 하위 분류 없을 시 안내, chip 형태로 선택 경로 표시 및 개별 삭제 지원
태그: 4x5 그리드 버튼, 최대 3개 선택, chip 형태로 표시 및 삭제, 비동기 로딩/에러 처리

3. **폼 검증 및 에러 처리 방식 통일**
모든 필수 입력값 검증을 폼 필드 순서대로 수행 (상품명 → 상품 설명 → 카테고리 → 태그 → 옵션 → 정보제공고시)
브라우저 네이티브 required 속성 제거, 모든 에러 메시지를 공통 ErrorDialog 모달로 표시
옵션별 필수값(옵션명, 가격, 전성분) 누락 시 상세 메시지 제공

4. **API 연동 및 백엔드 호환성**
상품 등록 시 multipart/form-data로 전송 (product: JSON, optionImages: 파일)
Spring 백엔드와 호환되는 Content-Type 및 데이터 구조 적용

5. **AuthGuard 적용 및 인증 흐름 개선**
상품 등록 페이지에서 AuthGuard를 적용하여 인증/권한이 없는 사용자는 진입 자체가 불가하도록 개선
인증되지 않은 사용자는 API 호출 없이 즉시 로그인 페이지로 리다이렉트됨
인증 후에만 상품 등록 관련 API가 호출되어, 불필요한 서버 부하 및 403 에러 로그 방지

6. **기타**
SuccessDialog/ ErrorDialog를 통한 일관된 사용자 피드백
코드 모듈화, 타입 안전성 강화, UX 및 접근성 개선

## 🛠️ Technical Concerns

## 🙂 To Reviewer
현재 테스트 했을 때 DB, S3 스토리지에 저장 되는 부분까지 확인 했습니다! 한 번 테스트 해주시면 좋을 것 같습니다
또한 화면 구성했을 때 폼 검증 및 에러 모달 표시가 순서대로 보이는지와 등록에 성공했을 때 모달 창 디자인이 잘 적용되었는지와 
AuthGuard를 적절히 사용해서 상품 등록 페이지에 로그인 없이 접근하려 했을 때 로그인 화면으로 제대로 이동하는지에 대해서 확인 부탁드립니다..!

## 📋 To Do
상품 조회 API 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 상품 등록 페이지가 인증된 판매자만 접근할 수 있도록 변경되었습니다.
  * 상품 등록 시 카테고리 및 태그 정보를 서버에서 동적으로 불러와서 사용합니다.
  * 상품 등록 폼에 클라이언트 측 유효성 검사, 로딩 및 오류 안내, 등록 성공/실패 안내 다이얼로그가 추가되었습니다.

* **버그 수정**
  * 카테고리, 태그, 옵션 입력 필드의 필수 입력 속성이 브라우저 기본 검사 대신 자체 로직으로 처리됩니다.
  * 이미지 업로드 필드는 PNG 및 JPEG 파일만 허용하도록 제한되었습니다.

* **개선 사항**
  * 카테고리 및 태그 선택 UI가 동적으로 데이터와 상태(로딩/오류)를 반영하도록 개선되었습니다.
  * 옵션 입력 필드가 재료 정보 입력으로 변경되고, 관련 UI와 상태 관리가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->