### PR TITLE
회원 배송지 관리 API 연동

### DIFF
--- a/src/app/mypage/address/page.tsx
+++ b/src/app/mypage/address/page.tsx
@@ -1,17 +1,46 @@
 'use client';
 
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { MyPageLayout } from '@/components/mypage/MyPageLayout';
 import { AddressCard } from '@/components/mypage/address';
-import { NoticeBanner, PageHeader, LoadingSkeleton } from '@/components/common';
+import { NoticeBanner, PageHeader, LoadingSkeleton, ErrorDialog } from '@/components/common';
 import Link from 'next/link';
 import { FORM_STYLES } from '@/constants/form-styles';
 import { cn } from '@/lib/utils';
 import { AuthGuard } from '@/components/auth/AuthGuard';
 import { useAddressList } from '@/hooks/useAddressList';
+import { deleteShippingAddress } from '@/services/memberService';
 
 function AddressListPageContent() {
-  const { addresses, loading, error } = useAddressList();
+  const { addresses, loading, error, refetch } = useAddressList();
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const handleDeleteClick = (id: number) => {
+    setDeleteTargetId(id);
+    setIsDeleteDialogOpen(true);
+    setDeleteError(null);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTargetId) return;
+    try {
+      await deleteShippingAddress(deleteTargetId);
+      setIsDeleteDialogOpen(false);
+      setDeleteTargetId(null);
+      await refetch();
+    } catch (err: any) {
+      setDeleteError(err?.response?.data?.message || err?.message || '삭제에 실패했습니다.');
+    }
+  };
+
+  const handleDeleteDialogClose = () => {
+    setIsDeleteDialogOpen(false);
+    setDeleteTargetId(null);
+    setDeleteError(null);
+  };
 
   if (loading) {
     return (
@@ -63,7 +92,9 @@ function AddressListPageContent() {
           ) : (
             [...addresses]
               .sort((a, b) => (b.is_default ? 1 : 0) - (a.is_default ? 1 : 0))
-              .map((address) => <AddressCard key={address.id} address={address} />)
+              .map((address) => (
+                <AddressCard key={address.id} address={address} onDelete={handleDeleteClick} />
+              ))
           )}
         </div>
 
@@ -76,6 +107,25 @@ function AddressListPageContent() {
           </Link>
         </div>
       </div>
+      {/* 삭제 확인 다이얼로그 */}
+      <ErrorDialog
+        isOpen={isDeleteDialogOpen}
+        onClose={handleDeleteDialogClose}
+        title="배송지 삭제"
+        message={deleteError ? deleteError : '정말 이 배송지를 삭제하시겠습니까?'}
+        errorDetails={deleteError ? undefined : ''}
+      />
+      {!deleteError && isDeleteDialogOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <Button
+            onClick={handleDeleteConfirm}
+            className="mt-4 w-full max-w-xs"
+            variant="destructive"
+          >
+            삭제하기
+          </Button>
+        </div>
+      )}
     </MyPageLayout>
   );
 }

--- a/src/app/mypage/address/page.tsx
+++ b/src/app/mypage/address/page.tsx
@@ -11,12 +11,20 @@ import { cn } from '@/lib/utils';
 import { AuthGuard } from '@/components/auth/AuthGuard';
 import { useAddressList } from '@/hooks/useAddressList';
 import { deleteShippingAddress } from '@/services/memberService';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
 
 function AddressListPageContent() {
   const { addresses, loading, error, refetch } = useAddressList();
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const handleDeleteClick = (id: number) => {
     setDeleteTargetId(id);
@@ -26,13 +34,17 @@ function AddressListPageContent() {
 
   const handleDeleteConfirm = async () => {
     if (!deleteTargetId) return;
+    setIsDeleting(true);
     try {
       await deleteShippingAddress(deleteTargetId);
       setIsDeleteDialogOpen(false);
       setDeleteTargetId(null);
+      setDeleteError(null);
       await refetch();
     } catch (err: any) {
       setDeleteError(err?.response?.data?.message || err?.message || '삭제에 실패했습니다.');
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -108,24 +120,30 @@ function AddressListPageContent() {
         </div>
       </div>
       {/* 삭제 확인 다이얼로그 */}
-      <ErrorDialog
-        isOpen={isDeleteDialogOpen}
-        onClose={handleDeleteDialogClose}
-        title="배송지 삭제"
-        message={deleteError ? deleteError : '정말 이 배송지를 삭제하시겠습니까?'}
-        errorDetails={deleteError ? undefined : ''}
-      />
-      {!deleteError && isDeleteDialogOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <Button
-            onClick={handleDeleteConfirm}
-            className="mt-4 w-full max-w-xs"
-            variant="destructive"
-          >
-            삭제하기
-          </Button>
-        </div>
-      )}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={handleDeleteDialogClose}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>배송지 삭제</DialogTitle>
+          </DialogHeader>
+          {deleteError ? (
+            <div className="mb-4 text-sm text-red-500">{deleteError}</div>
+          ) : (
+            <div className="mb-4 text-text-200">정말 이 배송지를 삭제하시겠습니까?</div>
+          )}
+          <DialogFooter>
+            <Button onClick={handleDeleteDialogClose} variant="outline">
+              취소
+            </Button>
+            <Button
+              onClick={handleDeleteConfirm}
+              className={FORM_STYLES.button.pinkOutline}
+              disabled={isDeleting}
+            >
+              삭제하기
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </MyPageLayout>
   );
 }

--- a/src/app/mypage/address/page.tsx
+++ b/src/app/mypage/address/page.tsx
@@ -61,7 +61,9 @@ function AddressListPageContent() {
               <p className="text-center text-text-300">등록된 배송지가 없습니다.</p>
             </div>
           ) : (
-            addresses.map((address) => <AddressCard key={address.id} address={address} />)
+            [...addresses]
+              .sort((a, b) => (b.is_default ? 1 : 0) - (a.is_default ? 1 : 0))
+              .map((address) => <AddressCard key={address.id} address={address} />)
           )}
         </div>
 

--- a/src/app/mypage/address/page.tsx
+++ b/src/app/mypage/address/page.tsx
@@ -1,14 +1,50 @@
+'use client';
+
 import { Button } from '@/components/ui/button';
 import { MyPageLayout } from '@/components/mypage/MyPageLayout';
 import { AddressCard } from '@/components/mypage/address';
-import { NoticeBanner, PageHeader } from '@/components/common';
+import { NoticeBanner, PageHeader, LoadingSkeleton } from '@/components/common';
 import Link from 'next/link';
 import { FORM_STYLES } from '@/constants/form-styles';
-import { addressListData } from '@/data/address';
 import { cn } from '@/lib/utils';
 import { AuthGuard } from '@/components/auth/AuthGuard';
+import { useAddressList } from '@/hooks/useAddressList';
 
 function AddressListPageContent() {
+  const { addresses, loading, error } = useAddressList();
+
+  if (loading) {
+    return (
+      <MyPageLayout>
+        <div className="flex flex-1 flex-col gap-6 py-4 md:py-6">
+          <PageHeader title="배송지 관리" />
+          <NoticeBanner message="배송지는 최대 5개까지 등록할 수 있어요" />
+          <div className="flex flex-col gap-4">
+            {[1, 2, 3].map((i) => (
+              <LoadingSkeleton key={i} className="h-32 w-full rounded-2xl" />
+            ))}
+          </div>
+        </div>
+      </MyPageLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MyPageLayout>
+        <div className="flex flex-1 flex-col gap-6 py-4 md:py-6">
+          <PageHeader title="배송지 관리" />
+          <div className="flex flex-col items-center justify-center py-8">
+            <p className="text-center text-text-300">{error}</p>
+            <Button onClick={() => window.location.reload()} className="mt-4" variant="outline">
+              다시 시도
+            </Button>
+          </div>
+        </div>
+      </MyPageLayout>
+    );
+  }
+
   return (
     <MyPageLayout>
       <div className="flex flex-1 flex-col gap-6 py-4 md:py-6">
@@ -20,9 +56,13 @@ function AddressListPageContent() {
 
         {/* 배송지 리스트 */}
         <div className="flex flex-col gap-4">
-          {addressListData.map((address) => (
-            <AddressCard key={address.id} address={address} />
-          ))}
+          {addresses.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8">
+              <p className="text-center text-text-300">등록된 배송지가 없습니다.</p>
+            </div>
+          ) : (
+            addresses.map((address) => <AddressCard key={address.id} address={address} />)
+          )}
         </div>
 
         {/* 배송지 추가 버튼 */}

--- a/src/app/mypage/address/register/page.tsx
+++ b/src/app/mypage/address/register/page.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { MyPageLayout } from '@/components/mypage/MyPageLayout';
 import { AddressFormFields } from '@/components/mypage/address';
 import { Card, CardContent } from '@/components/ui/card';
-import { PageHeader, CardSkeleton } from '@/components/common';
+import { PageHeader, CardSkeleton, ErrorDialog } from '@/components/common';
 import { FORM_STYLES } from '@/constants/form-styles';
 import { useAddress } from '@/hooks/useAddress';
 import { AuthGuard } from '@/components/auth/AuthGuard';
@@ -19,7 +19,17 @@ function AddressRegisterSkeleton() {
 }
 
 function AddressRegisterContent() {
-  const { addressData, isEditMode, handleInputChange, handleSubmit } = useAddress();
+  const {
+    addressData,
+    isEditMode,
+    handleInputChange,
+    handleSubmit,
+    isErrorDialogOpen,
+    errorDialogTitle,
+    errorDialogMessage,
+    errorDialogDetails,
+    onCloseErrorDialog,
+  } = useAddress();
 
   return (
     <MyPageLayout>
@@ -40,6 +50,13 @@ function AddressRegisterContent() {
           </form>
         </CardContent>
       </Card>
+      <ErrorDialog
+        isOpen={isErrorDialogOpen}
+        onClose={onCloseErrorDialog}
+        title={errorDialogTitle}
+        message={errorDialogMessage}
+        errorDetails={errorDialogDetails}
+      />
     </MyPageLayout>
   );
 }

--- a/src/components/mypage/address/AddressCard.tsx
+++ b/src/components/mypage/address/AddressCard.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-import { AddressData } from '@/data/address';
+import { ShippingAddress } from '@/types/api';
 import { FORM_STYLES } from '@/constants/form-styles';
 
 interface AddressCardProps {
-  address: AddressData;
+  address: ShippingAddress;
 }
 
 export function AddressCard({ address }: AddressCardProps) {
@@ -14,8 +14,8 @@ export function AddressCard({ address }: AddressCardProps) {
     <Card className="w-full rounded-2xl border-0 bg-bg-100 p-6 shadow-sm">
       <CardContent className="p-0">
         <div className="mb-2 flex items-center">
-          <span className="text-base font-semibold text-text-100">{address.addressName}</span>
-          {address.isDefault && (
+          <span className="text-base font-semibold text-text-100">{address.label}</span>
+          {address.is_default && (
             <span className="ml-2 rounded-full bg-primary-300 px-3 py-1 text-xs font-semibold text-text-on">
               기본 배송지
             </span>

--- a/src/components/mypage/address/AddressCard.tsx
+++ b/src/components/mypage/address/AddressCard.tsx
@@ -4,14 +4,27 @@ import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { ShippingAddress } from '@/types/api';
 import { FORM_STYLES } from '@/constants/form-styles';
+import { X } from 'lucide-react';
 
 interface AddressCardProps {
   address: ShippingAddress;
+  onDelete?: (id: number) => void;
 }
 
-export function AddressCard({ address }: AddressCardProps) {
+export function AddressCard({ address, onDelete }: AddressCardProps) {
   return (
-    <Card className="w-full rounded-2xl border-0 bg-bg-100 p-6 shadow-sm">
+    <Card className="relative w-full rounded-2xl border-0 bg-bg-100 p-6 shadow-sm">
+      {/* 삭제 아이콘 버튼 */}
+      {onDelete && (
+        <button
+          type="button"
+          className="absolute right-4 top-4 rounded p-1 transition hover:bg-bg-200"
+          aria-label="배송지 삭제"
+          onClick={() => onDelete(address.id)}
+        >
+          <X className="h-5 w-5 text-text-300 hover:text-primary-300" />
+        </button>
+      )}
       <CardContent className="p-0">
         <div className="mb-2 flex items-center">
           <span className="text-base font-semibold text-text-100">{address.label}</span>

--- a/src/components/mypage/address/AddressFormFields.tsx
+++ b/src/components/mypage/address/AddressFormFields.tsx
@@ -15,7 +15,7 @@ interface AddressFormFieldsProps {
     zonecode: string;
     address1: string;
     address2: string;
-    addressDetail: string;
+    // addressDetail: string; // 삭제
   };
   onInputChange: (field: string, value: string | boolean) => void;
   showDefaultCheckbox?: boolean;
@@ -133,19 +133,7 @@ export function AddressFormFields({
           required
         />
       </FormField>
-
-      {/* 상세주소 */}
-      <FormField label="상세주소" required>
-        <Input
-          type="text"
-          placeholder="상세주소를 입력해주세요"
-          value={addressData.addressDetail}
-          onChange={(e) => onInputChange('addressDetail', e.target.value)}
-          className={FORM_STYLES.input.base + ' ' + FORM_STYLES.input.focus}
-          maxLength={100}
-          required
-        />
-      </FormField>
+      {/* 상세주소 FormField 완전 삭제 */}
     </div>
   );
 }

--- a/src/data/address.ts
+++ b/src/data/address.ts
@@ -7,7 +7,6 @@ export interface AddressData {
   zonecode: string;
   address1: string;
   address2: string;
-  addressDetail: string;
 }
 
 // 배송지 목록 mock 데이터
@@ -20,7 +19,6 @@ export const addressListData: AddressData[] = [
     address1: '서울특별시 서초구 강남대로 327, 2층 (서초동, 대륭서초타워)',
     address2: '서울특별시 서초구 서초동 1337-20, 대륭서초타워 2층',
     phone: '010-0000-0000',
-    addressDetail: '',
   },
   {
     id: 2,
@@ -30,7 +28,6 @@ export const addressListData: AddressData[] = [
     address1: '서울특별시 강남구 테헤란로 501, 3층 (삼성동, 브이플렉스)',
     address2: '서울특별시 강남구 삼성동 159-1, 브이플렉스 3층',
     phone: '010-1234-5678',
-    addressDetail: '개발팀',
   },
   {
     id: 3,
@@ -40,7 +37,6 @@ export const addressListData: AddressData[] = [
     address1: '경기도 성남시 분당구 판교로 242, 판교디지털센터 A동 3층',
     address2: '경기도 성남시 분당구 삼평동 681, 판교디지털센터 A3층',
     phone: '010-9876-5432',
-    addressDetail: '',
   },
 ];
 
@@ -54,7 +50,6 @@ export const mockAddressData: Record<number, AddressData> = {
     zonecode: '06627',
     address1: '서울특별시 서초구 강남대로 327, 2층 (서초동, 대륭서초타워)',
     address2: '서울특별시 서초구 서초동 1337-20, 대륭서초타워 2층',
-    addressDetail: '',
   },
   2: {
     id: 2,
@@ -64,7 +59,6 @@ export const mockAddressData: Record<number, AddressData> = {
     zonecode: '06123',
     address1: '서울특별시 강남구 테헤란로 501, 3층 (삼성동, 브이플렉스)',
     address2: '서울특별시 강남구 삼성동 159-1, 브이플렉스 3층',
-    addressDetail: '개발팀',
   },
   3: {
     id: 3,
@@ -74,6 +68,5 @@ export const mockAddressData: Record<number, AddressData> = {
     zonecode: '13529',
     address1: '경기도 성남시 분당구 판교로 242, 판교디지털센터 A동 3층',
     address2: '경기도 성남시 분당구 삼평동 681, 판교디지털센터 A3층',
-    addressDetail: '',
   },
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -13,6 +13,7 @@ export { useReviewWrite } from './useReviewWrite';
 export { useSafeNavigation, useSafeRouter, useSafeSearchParams } from './useSafeNavigation';
 export { useSignupForm } from './useSignupForm';
 export { useAddress } from './useAddress';
+export { useAddressList } from './useAddressList';
 export { useBeautyProfileEdit } from './useBeautyProfileEdit';
 export { useBeautyProfileUtils } from './useBeautyProfileUtils';
 export { useDropdown } from './useDropdown';

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSafeSearchParams, useSafeRouter } from '@/hooks';
 import { mockAddressData, AddressData } from '@/data/address';
+import { postShippingAddress } from '@/services/memberService';
 
 export const useAddress = () => {
   const router = useSafeRouter();
@@ -32,14 +33,29 @@ export const useAddress = () => {
   }, []);
 
   const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
+    async (e: React.FormEvent) => {
       e.preventDefault();
-      // TODO: 실제 배송지 저장 API 연동 필요
-      // TODO: 실제 배송지 저장 API 호출
-      // 저장 후 배송지 관리 페이지로 이동
-      router.push('/mypage/address');
+      if (isEditMode) {
+        // 수정 모드는 아직 미구현
+        router.push('/mypage/address');
+        return;
+      }
+      try {
+        await postShippingAddress({
+          label: addressData.addressName,
+          phone: addressData.phone,
+          zonecode: addressData.zonecode,
+          address1: addressData.address1,
+          address2: addressData.address2,
+          isDefault: addressData.isDefault,
+        });
+        router.push('/mypage/address');
+      } catch (err) {
+        alert('배송지 등록에 실패했습니다.');
+        console.error('배송지 등록 오류:', err);
+      }
     },
-    [addressData, router],
+    [addressData, router, isEditMode],
   );
 
   const resetForm = useCallback(() => {

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -1,7 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSafeSearchParams, useSafeRouter } from '@/hooks';
 import { mockAddressData, AddressData } from '@/data/address';
-import { postShippingAddress, getShippingAddressById } from '@/services/memberService';
+import {
+  postShippingAddress,
+  getShippingAddressById,
+  putShippingAddress,
+} from '@/services/memberService';
 
 export const useAddress = () => {
   const router = useSafeRouter();
@@ -47,27 +51,33 @@ export const useAddress = () => {
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
-      if (isEditMode) {
-        // 수정 모드는 아직 미구현
-        router.push('/mypage/address');
-        return;
-      }
       try {
-        await postShippingAddress({
-          label: addressData.addressName,
-          phone: addressData.phone,
-          zonecode: addressData.zonecode,
-          address1: addressData.address1,
-          address2: addressData.address2,
-          isDefault: addressData.isDefault,
-        });
+        if (isEditMode && addressId) {
+          await putShippingAddress(Number(addressId), {
+            label: addressData.addressName,
+            phone: addressData.phone,
+            zonecode: addressData.zonecode,
+            address1: addressData.address1,
+            address2: addressData.address2,
+            isDefault: addressData.isDefault,
+          });
+        } else {
+          await postShippingAddress({
+            label: addressData.addressName,
+            phone: addressData.phone,
+            zonecode: addressData.zonecode,
+            address1: addressData.address1,
+            address2: addressData.address2,
+            isDefault: addressData.isDefault,
+          });
+        }
         router.push('/mypage/address');
       } catch (err) {
-        alert('배송지 등록에 실패했습니다.');
-        console.error('배송지 등록 오류:', err);
+        alert(isEditMode ? '배송지 수정에 실패했습니다.' : '배송지 등록에 실패했습니다.');
+        console.error(isEditMode ? '배송지 수정 오류:' : '배송지 등록 오류:', err);
       }
     },
-    [addressData, router, isEditMode],
+    [addressData, router, isEditMode, addressId],
   );
 
   const resetForm = useCallback(() => {

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSafeSearchParams, useSafeRouter } from '@/hooks';
 import { mockAddressData, AddressData } from '@/data/address';
-import { postShippingAddress } from '@/services/memberService';
+import { postShippingAddress, getShippingAddressById } from '@/services/memberService';
 
 export const useAddress = () => {
   const router = useSafeRouter();
@@ -19,13 +19,27 @@ export const useAddress = () => {
     addressDetail: '',
   });
 
-  // 수정 모드일 때 기존 데이터 로드
+  // 수정 모드일 때 기존 데이터 API로 로드
   useEffect(() => {
-    if (isEditMode && addressId && mockAddressData[Number(addressId)]) {
-      const existingData = mockAddressData[Number(addressId)];
-      const { id, ...dataWithoutId } = existingData;
-      setAddressData(dataWithoutId);
-    }
+    const fetchAddress = async () => {
+      if (isEditMode && addressId) {
+        try {
+          const data = await getShippingAddressById(Number(addressId));
+          setAddressData({
+            addressName: data.label,
+            isDefault: data.is_default,
+            phone: data.phone,
+            zonecode: data.zonecode,
+            address1: data.address1,
+            address2: data.address2,
+            addressDetail: '', // addressDetail은 API에 없으므로 빈 값
+          });
+        } catch (err) {
+          alert('배송지 정보를 불러오지 못했습니다.');
+        }
+      }
+    };
+    fetchAddress();
   }, [isEditMode, addressId]);
 
   const handleInputChange = useCallback((field: string, value: string | boolean) => {

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -16,7 +16,6 @@ export const useAddress = () => {
     zonecode: '',
     address1: '',
     address2: '',
-    addressDetail: '',
   });
 
   // 수정 모드일 때 기존 데이터 API로 로드
@@ -32,7 +31,6 @@ export const useAddress = () => {
             zonecode: data.zonecode,
             address1: data.address1,
             address2: data.address2,
-            addressDetail: '', // addressDetail은 API에 없으므로 빈 값
           });
         } catch (err) {
           alert('배송지 정보를 불러오지 못했습니다.');
@@ -80,7 +78,6 @@ export const useAddress = () => {
       zonecode: '',
       address1: '',
       address2: '',
-      addressDetail: '',
     });
   }, []);
 

--- a/src/hooks/useAddress.ts
+++ b/src/hooks/useAddress.ts
@@ -22,6 +22,12 @@ export const useAddress = () => {
     address2: '',
   });
 
+  // 에러 다이얼로그 상태
+  const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
+  const [errorDialogTitle, setErrorDialogTitle] = useState('');
+  const [errorDialogMessage, setErrorDialogMessage] = useState('');
+  const [errorDialogDetails, setErrorDialogDetails] = useState('');
+
   // 수정 모드일 때 기존 데이터 API로 로드
   useEffect(() => {
     const fetchAddress = async () => {
@@ -36,8 +42,11 @@ export const useAddress = () => {
             address1: data.address1,
             address2: data.address2,
           });
-        } catch (err) {
-          alert('배송지 정보를 불러오지 못했습니다.');
+        } catch (err: any) {
+          setErrorDialogTitle('배송지 조회 실패');
+          setErrorDialogMessage('배송지 정보를 불러오지 못했습니다.');
+          setErrorDialogDetails(err?.message || '');
+          setIsErrorDialogOpen(true);
         }
       }
     };
@@ -72,8 +81,13 @@ export const useAddress = () => {
           });
         }
         router.push('/mypage/address');
-      } catch (err) {
-        alert(isEditMode ? '배송지 수정에 실패했습니다.' : '배송지 등록에 실패했습니다.');
+      } catch (err: any) {
+        setErrorDialogTitle(isEditMode ? '배송지 수정 실패' : '배송지 등록 실패');
+        setErrorDialogMessage(
+          err?.response?.data?.message || err?.message || '알 수 없는 오류가 발생했습니다.',
+        );
+        setErrorDialogDetails(err?.response?.data?.errorDetails || '');
+        setIsErrorDialogOpen(true);
         console.error(isEditMode ? '배송지 수정 오류:' : '배송지 등록 오류:', err);
       }
     },
@@ -91,11 +105,23 @@ export const useAddress = () => {
     });
   }, []);
 
+  const onCloseErrorDialog = useCallback(() => {
+    setIsErrorDialogOpen(false);
+    setErrorDialogTitle('');
+    setErrorDialogMessage('');
+    setErrorDialogDetails('');
+  }, []);
+
   return {
     addressData,
     isEditMode,
     handleInputChange,
     handleSubmit,
     resetForm,
+    isErrorDialogOpen,
+    errorDialogTitle,
+    errorDialogMessage,
+    errorDialogDetails,
+    onCloseErrorDialog,
   };
 };

--- a/src/hooks/useAddressList.ts
+++ b/src/hooks/useAddressList.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import { getShippingAddresses } from '@/services/memberService';
+import { ShippingAddress } from '@/types/api';
+
+export function useAddressList() {
+  const [addresses, setAddresses] = useState<ShippingAddress[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAddresses = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getShippingAddresses();
+      setAddresses(data.addresses);
+    } catch (err: any) {
+      console.error('배송지 조회 오류:', err);
+      setError('배송지 조회 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAddresses();
+  }, []);
+
+  return {
+    addresses,
+    loading,
+    error,
+    refetch: fetchAddresses,
+  };
+}

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -65,3 +65,8 @@ export async function postShippingAddress(data: ShippingAddressRequest) {
   });
   return response.data.data;
 }
+
+export async function getShippingAddressById(addressId: number) {
+  const response = await api.get(`/members/shipping-addresses/${addressId}`);
+  return response.data.data;
+}

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -85,5 +85,5 @@ export async function putShippingAddress(addressId: number, data: ShippingAddres
 
 export async function deleteShippingAddress(addressId: number) {
   const response = await api.delete(`/members/shipping-addresses/${addressId}`);
-  return response.data;
+  return response.data.data;
 }

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -82,3 +82,8 @@ export async function putShippingAddress(addressId: number, data: ShippingAddres
   });
   return response.data.data;
 }
+
+export async function deleteShippingAddress(addressId: number) {
+  const response = await api.delete(`/members/shipping-addresses/${addressId}`);
+  return response.data;
+}

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -70,3 +70,15 @@ export async function getShippingAddressById(addressId: number) {
   const response = await api.get(`/members/shipping-addresses/${addressId}`);
   return response.data.data;
 }
+
+export async function putShippingAddress(addressId: number, data: ShippingAddressRequest) {
+  const response = await api.put(`/members/shipping-addresses/${addressId}`, {
+    label: data.label,
+    phone: data.phone,
+    zonecode: data.zonecode,
+    address1: data.address1,
+    address2: data.address2,
+    isDefault: data.isDefault,
+  });
+  return response.data.data;
+}

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -22,6 +22,15 @@ export interface ProfileResponse {
   phone?: string;
 }
 
+export interface ShippingAddressRequest {
+  label: string;
+  phone: string;
+  zonecode: string;
+  address1: string;
+  address2: string;
+  isDefault: boolean;
+}
+
 export async function checkNicknameDuplicate(nickname: string): Promise<boolean> {
   // 한국어 닉네임을 고려하여 URL 인코딩
   const encodedNickname = encodeURIComponent(nickname);
@@ -42,5 +51,17 @@ export async function getProfile() {
 
 export async function getShippingAddresses() {
   const response = await api.get('/members/shipping-addresses');
+  return response.data.data;
+}
+
+export async function postShippingAddress(data: ShippingAddressRequest) {
+  const response = await api.post('/members/shipping-addresses', {
+    label: data.label,
+    phone: data.phone,
+    zonecode: data.zonecode,
+    address1: data.address1,
+    address2: data.address2,
+    isDefault: data.isDefault,
+  });
   return response.data.data;
 }

--- a/src/services/memberService.ts
+++ b/src/services/memberService.ts
@@ -39,3 +39,8 @@ export async function getProfile() {
   const response = await api.get('/members/me');
   return response.data.data;
 }
+
+export async function getShippingAddresses() {
+  const response = await api.get('/members/shipping-addresses');
+  return response.data.data;
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -45,3 +45,21 @@ export interface SocialLoginRequest {
   provider: string;
   code: string;
 }
+
+// 배송지 관련 타입
+export interface ShippingAddress {
+  id: number;
+  member_id: number;
+  label: string;
+  phone: string;
+  zonecode: string;
+  address1: string;
+  address2: string;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ShippingAddressResponse {
+  addresses: ShippingAddress[];
+}


### PR DESCRIPTION
## ⭐️ Issue Number

- #79

## 🚩 Summary
아래 API와 프론트를 연동했습니다.
- 내 배송지 조회 API 연동
- 배송지 추가 API 연동
- 배송지 수정 API 연동
- 배송지 삭제 API 연동
-  특정 배송지 조회 API 연동 (배송지 수정 시 기존 배송지 정보를 제공)

## 🛠️ Technical Concerns &  🙂 To Reviewer

- 다이얼로그는 현재 구현된 다이얼로그의 디자인과 동일하게 구현하였습니다.
- 삭제하기 다이얼로그는 약간 디자인이 다른데 확인해주시면 감사하겠습니다!
- 최대한 CSS 코드는 건드리지 않았습니다.
- 배송지 삭제버튼을 추가하였는데, 디자인 괜찮은지 확인해주시면 감사하겠습니다!

## 📋 To Do
- 회원 탈퇴 API 연동


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 배송지 목록이 실시간으로 불러와지고, 삭제 기능에 확인 다이얼로그 및 오류 처리 기능이 추가되었습니다.
  * 배송지 등록/수정 시 오류 발생 시 상세 정보를 표시하는 오류 다이얼로그가 추가되었습니다.

* **버그 수정**
  * 배송지 목록, 등록, 수정 시 오류 발생 시 사용자에게 안내 메시지와 재시도 기능이 제공됩니다.

* **기능 개선**
  * 배송지 상세주소 입력란이 제거되어 입력이 간소화되었습니다.
  * 기본 배송지가 목록 상단에 우선적으로 표시됩니다.

* **UI/UX**
  * 배송지 삭제 버튼이 각 카드에 추가되어 직접 삭제가 가능합니다.
  * 로딩 중에는 스켈레톤 UI, 오류 시 안내 메시지, 배송지 없음 안내가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->