### PR TITLE
메인 홈 실시간 랭킹 및 카테고리 랭킹 API 연동

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,6 +19,11 @@ const nextConfig = {
         hostname: 'i.pinimg.com',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'ururu-bucket.s3.ap-northeast-2.amazonaws.com',
+        pathname: '/**',
+      },
     ],
   },
   async rewrites() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,10 @@ import {
   historyBasedProducts,
 } from '@/data/home';
 import { WithdrawnMemberAlert } from '@/components/common/WithdrawnMemberAlert';
+import { useEffect, useState } from 'react';
+import { fetchGroupBuyTop3 } from '@/services/groupbuyService';
+import type { GroupBuyTop3 } from '@/types/groupbuy';
+import RealtimeBestFetcher from '@/components/home/RealtimeBestFetcher';
 
 export const metadata: Metadata = {
   title: '우르르 - 뷰티 공동구매 커머스',
@@ -62,7 +66,7 @@ export default function Home() {
             </div>
             {/* 실시간 베스트: 더 넓게 */}
             <div className="h-[360px] w-[480px] flex-shrink-0">
-              <RealtimeBestSection products={realtimeBestProducts} className="h-full" />
+              <RealtimeBestFetcher className="h-full" />
             </div>
           </div>
         </section>
@@ -71,7 +75,7 @@ export default function Home() {
         <main className="space-y-20">
           {/* 실시간 베스트 (모바일/태블릿만) */}
           <section className="lg:hidden">
-            <RealtimeBestSection products={realtimeBestProducts} />
+            <RealtimeBestFetcher />
           </section>
 
           {/* 개인화 추천 */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
           <PersonalizedSection products={personalizedProducts} />
 
           {/* 카테고리 랭킹 */}
-          <CategoryRankingSection categories={categoryRankings} />
+          <CategoryRankingSection />
 
           {/* 숏구(숏폼) 섹션 */}
           <ShortFormSection />

--- a/src/components/home/CategoryRankingSection.tsx
+++ b/src/components/home/CategoryRankingSection.tsx
@@ -109,7 +109,11 @@ export function CategoryRankingSection({ className = '' }: { className?: string 
         {loading && <div className="text-center text-sm text-text-200">로딩 중...</div>}
         {error && <div className="text-center text-sm text-red-400">{error}</div>}
         {!loading && !error && activeProducts.length === 0 && (
-          <div className="text-center text-sm text-text-200">랭킹 데이터가 없습니다.</div>
+          <div className="flex flex-col items-center justify-center py-8 md:py-12">
+            <div className="mb-4 text-6xl">🏆</div>
+            <h2 className="mb-2 text-xl font-semibold text-text-100">랭킹 데이터가 없습니다</h2>
+            <p className="text-text-200">다른 카테고리를 선택해보세요!</p>
+          </div>
         )}
         {!loading && !error && activeProducts.length > 0 && (
           <>

--- a/src/components/home/RealtimeBestFetcher.tsx
+++ b/src/components/home/RealtimeBestFetcher.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchGroupBuyTop3 } from '@/services/groupbuyService';
+import type { GroupBuyTop3 } from '@/types/groupbuy';
+import { RealtimeBestSection } from './RealtimeBestSection';
+import type { Product } from '@/types/product';
+
+export default function RealtimeBestFetcher({ className = '' }: { className?: string }) {
+  const [groupBuyTop3, setGroupBuyTop3] = useState<GroupBuyTop3[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchGroupBuyTop3()
+      .then((res) => {
+        setGroupBuyTop3(res.data);
+        setError(null);
+      })
+      .catch(() => {
+        setError('실시간 베스트 데이터를 불러오지 못했습니다.');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  // GroupBuyTop3 -> Product 변환
+  const convertToProduct = (item: GroupBuyTop3): Product => ({
+    id: String(item.id),
+    name: item.title,
+    mainImage: item.thumbnailUrl,
+    thumbnails: [],
+    detailImages: [],
+    price: item.displayFinalPrice,
+    originalPrice: item.startPrice,
+    discountRate: item.maxDiscountRate,
+    point: 0,
+    participants: item.orderCount,
+    targetParticipants: 0,
+    remainingDays: Math.max(
+      0,
+      Math.ceil((new Date(item.endsAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)),
+    ),
+    category: { main: '', sub: '' },
+    shippingInfo: { type: '', description: '', shippingFee: '' },
+    rewardTiers: [],
+    options: [],
+  });
+  const realtimeBestProducts = groupBuyTop3.map(convertToProduct);
+
+  // 안내 메시지만 단독으로 노출
+  if (loading) return <div className="text-center text-sm text-text-200">로딩 중...</div>;
+  if (error) return <div className="text-center text-sm text-red-400">{error}</div>;
+  if (realtimeBestProducts.length === 0) {
+    return (
+      <div className="text-center text-sm text-text-200">실시간 베스트 공동구매가 없습니다.</div>
+    );
+  }
+
+  return <RealtimeBestSection products={realtimeBestProducts} className={className} />;
+}

--- a/src/services/groupbuyService.ts
+++ b/src/services/groupbuyService.ts
@@ -5,3 +5,8 @@ export async function fetchGroupBuyTop3(): Promise<GroupBuyTop3Response> {
   const res = await api.get<GroupBuyTop3Response>('/groupbuys/top3');
   return res.data;
 }
+
+export async function fetchGroupBuyCategoryTop6(categoryId: number): Promise<GroupBuyTop3Response> {
+  const res = await api.get<GroupBuyTop3Response>(`/groupbuys/${categoryId}/top6`);
+  return res.data;
+}

--- a/src/services/groupbuyService.ts
+++ b/src/services/groupbuyService.ts
@@ -1,0 +1,7 @@
+import api from '@/lib/axios';
+import type { GroupBuyTop3Response } from '@/types/groupbuy';
+
+export async function fetchGroupBuyTop3(): Promise<GroupBuyTop3Response> {
+  const res = await api.get<GroupBuyTop3Response>('/groupbuys/top3');
+  return res.data;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './groupbuyService';

--- a/src/types/groupbuy.ts
+++ b/src/types/groupbuy.ts
@@ -1,0 +1,17 @@
+export interface GroupBuyTop3 {
+  id: number;
+  title: string;
+  thumbnailUrl: string;
+  displayFinalPrice: number;
+  startPrice: number;
+  maxDiscountRate: number;
+  endsAt: string;
+  orderCount: number;
+  createdAt: string;
+}
+
+export interface GroupBuyTop3Response {
+  success: boolean;
+  message: string;
+  data: GroupBuyTop3[];
+}

--- a/src/types/groupbuy.ts
+++ b/src/types/groupbuy.ts
@@ -15,3 +15,5 @@ export interface GroupBuyTop3Response {
   message: string;
   data: GroupBuyTop3[];
 }
+
+// 카테고리별 랭킹 API 응답도 GroupBuyTop3Response와 동일하게 사용 가능


### PR DESCRIPTION
## ⭐️ Issue Number

- #91

## 🚩 Summary

- 실시간 랭킹 API 연동
- 카테고리별 랭킹 API 연동

## 🛠️ Technical Concerns

## 🙂 To Reviewer
- 최대한 기존 디자인과 맞게 CSS코드는 건드리지 않고 구현하려고 했습니다!
- 다만 로딩중인 상태가 거슬리긴한데 이 부분만 확인 부탁드립니다. 더 좋은 의견 있으시면 반영할께요.
- 로그인 없이 랭킹 보여주기 위해 [백엔드 pr](https://github.com/UruruLab/Ururu-Backend/pull/197)올렸습니다. 같이 실행하시면 될꺼에요!

## 📋 To Do
- 랭킹 페이지 API 구현 및 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 실시간 베스트 그룹구매 상품을 자동으로 불러와 보여주는 기능이 추가되었습니다.
  * 카테고리별 그룹구매 랭킹이 API를 통해 동적으로 제공되며, 로딩/에러/데이터 없음 상태에 대한 안내가 개선되었습니다.

* **버그 수정**
  * 이미지 원격 소스에 중복된 호스트 설정이 추가되어 이미지 로딩 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->