### PR TITLE
마이페이지 환불 내역 조회 API 연동

### DIFF
--- a/src/app/mypage/refunds/page.tsx
+++ b/src/app/mypage/refunds/page.tsx
@@ -1,26 +1,47 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import { RefundStatusTabs, RefundCard } from '@/components/refunds';
-import { EmptyState, PageHeader } from '@/components/common';
-import { allRefunds, refundStatusSummary } from '@/data/refunds';
+import { EmptyState, PageHeader, LoadingSkeleton } from '@/components/common';
+import { useRefunds, useInfiniteScroll } from '@/hooks';
 import { RefundStatusFilter } from '@/types/refund';
 import { AuthGuard } from '@/components/auth/AuthGuard';
 
 function RefundsPageContent() {
   const [activeFilter, setActiveFilter] = useState<RefundStatusFilter>('all');
+  const { refunds, summary, loading, loadingMore, error, hasMore, loadMore } =
+    useRefunds(activeFilter);
 
-  const filteredRefunds = useMemo(() => {
-    if (activeFilter === 'all') {
-      return allRefunds;
-    }
-
-    return allRefunds.filter((refund) => refund.status === activeFilter);
-  }, [activeFilter]);
+  // 무한 스크롤 설정
+  useInfiniteScroll({
+    onLoadMore: loadMore,
+    hasMore,
+    loading: loadingMore,
+  });
 
   const handleFilterChange = (filter: RefundStatusFilter) => {
     setActiveFilter(filter);
   };
+
+  // 로딩 상태
+  if (loading) {
+    return (
+      <div className="flex flex-1 flex-col gap-6 py-4 md:py-6">
+        <PageHeader title="취소/환불 내역" />
+        <LoadingSkeleton />
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error) {
+    return (
+      <div className="flex flex-1 flex-col gap-6 py-4 md:py-6">
+        <PageHeader title="취소/환불 내역" />
+        <EmptyState title="데이터를 불러오는 중 오류가 발생했습니다." description={error} />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-1 flex-col gap-6 py-4 md:py-6">
@@ -29,17 +50,22 @@ function RefundsPageContent() {
 
       {/* 상태별 필터 탭 */}
       <RefundStatusTabs
-        summary={refundStatusSummary}
+        summary={summary}
         activeFilter={activeFilter}
         onFilterChange={handleFilterChange}
       />
 
       {/* 취소/환불 내역 리스트 */}
       <div className="space-y-12">
-        {filteredRefunds.length === 0 ? (
+        {refunds.length === 0 ? (
           <EmptyState title="취소/환불 내역이 없습니다." description="안전한 쇼핑을 도와드려요!" />
         ) : (
-          filteredRefunds.map((refund) => <RefundCard key={refund.id} refund={refund} />)
+          <>
+            {refunds.map((refund) => (
+              <RefundCard key={refund.id} refund={refund} />
+            ))}
+            {loadingMore && <LoadingSkeleton />}
+          </>
         )}
       </div>
     </div>

--- a/src/components/common/StatusBadge.tsx
+++ b/src/components/common/StatusBadge.tsx
@@ -1,7 +1,15 @@
 import { cn } from '@/lib/utils';
 
 interface StatusBadgeProps {
-  status: 'in_progress' | 'confirmed' | 'failed' | 'refund_pending' | 'COMPLETED' | 'REJECTED';
+  status:
+    | 'in_progress'
+    | 'confirmed'
+    | 'failed'
+    | 'refund_pending'
+    | 'APPROVED'
+    | 'COMPLETED'
+    | 'REJECTED'
+    | 'FAILED';
   className?: string;
 }
 
@@ -23,6 +31,11 @@ export function StatusBadge({ status, className = '' }: StatusBadgeProps) {
           label: '환불 대기중',
           className: 'bg-bg-200 text-text-200',
         };
+      case 'APPROVED':
+        return {
+          label: '환불 승인',
+          className: 'bg-primary-100 text-primary-200 border border-primary-200',
+        };
       case 'COMPLETED':
         return {
           label: '환불 완료',
@@ -32,6 +45,11 @@ export function StatusBadge({ status, className = '' }: StatusBadgeProps) {
         return {
           label: '환불 거절',
           className: 'bg-bg-200 text-text-300',
+        };
+      case 'FAILED':
+        return {
+          label: '환불 실패',
+          className: 'bg-primary-100 text-primary-200 border border-primary-200',
         };
       default:
         return {

--- a/src/components/refunds/RefundCard.tsx
+++ b/src/components/refunds/RefundCard.tsx
@@ -10,7 +10,7 @@ interface RefundCardProps {
 
 export function RefundCard({ refund }: RefundCardProps) {
   // 공구 실패로 인한 자동 환불인지 확인
-  const isFailedOrderRefund = refund.type === 'OTHER' && refund.reason.includes('공구 실패');
+  const isFailedOrderRefund = refund.type === 'GROUPBUY_FAIL';
 
   return (
     <div className="rounded-lg bg-bg-100 py-6">
@@ -38,9 +38,7 @@ export function RefundCard({ refund }: RefundCardProps) {
           <div className="mb-1 flex items-center space-x-2">
             <span className="text-sm font-medium text-text-100">공구 실패 자동 환불</span>
             {refund.refundedAt && (
-              <span className="text-xs text-text-200">
-                {refund.refundedAt.toLocaleDateString('ko-KR')} 완료
-              </span>
+              <span className="text-xs text-text-200">{formatDate(refund.refundedAt)} 완료</span>
             )}
           </div>
           <p className="text-sm text-text-200">{refund.reason}</p>
@@ -89,7 +87,7 @@ export function RefundCard({ refund }: RefundCardProps) {
           <div className="flex items-center justify-between">
             <span className="text-sm text-text-200">환불 사유</span>
             <span className="text-sm font-medium text-text-100">
-              {isFailedOrderRefund ? '공구 실패' : getRefundTypeLabel(refund.type)}
+              {getRefundTypeLabel(refund.type)}
             </span>
           </div>
           {/* 공구 실패인 경우 추가 안내 */}
@@ -100,12 +98,14 @@ export function RefundCard({ refund }: RefundCardProps) {
               </div>
             </div>
           )}
-          {/* 환불 완료일 (완료된 경우만) */}
-          {refund.status === 'COMPLETED' && refund.refundedAt && (
+          {/* 환불 승인일 (승인/완료/실패된 경우만) */}
+          {(refund.status === 'APPROVED' ||
+            refund.status === 'COMPLETED' ||
+            refund.status === 'FAILED') && (
             <div className="flex items-center justify-between">
-              <span className="text-sm text-text-200">환불 완료일</span>
+              <span className="text-sm text-text-200">환불 승인일</span>
               <span className="text-sm font-medium text-text-100">
-                {formatDate(refund.refundedAt)}
+                {refund.refundedAt ? formatDate(refund.refundedAt) : formatDate(refund.createdAt)}
               </span>
             </div>
           )}

--- a/src/components/refunds/RefundStatusTabs.tsx
+++ b/src/components/refunds/RefundStatusTabs.tsx
@@ -19,10 +19,11 @@ export function RefundStatusTabs({ summary, activeFilter, onFilterChange }: Refu
     {
       value: 'all' as const,
       label: '전체',
-      count: summary.completed + summary.rejected,
     },
-    { value: 'COMPLETED' as const, label: '환불 완료', count: summary.completed },
-    { value: 'REJECTED' as const, label: '환불 거절', count: summary.rejected },
+    { value: 'REJECTED' as const, label: '환불 거절' },
+    { value: 'APPROVED' as const, label: '환불 승인' },
+    { value: 'COMPLETED' as const, label: '환불 완료' },
+    { value: 'FAILED' as const, label: '환불 실패' },
   ];
 
   const selectedTab = tabs.find((tab) => tab.value === activeFilter);
@@ -35,9 +36,6 @@ export function RefundStatusTabs({ summary, activeFilter, onFilterChange }: Refu
         className={`flex items-center gap-2 rounded-lg border border-bg-300 bg-bg-100 px-3 py-2 text-sm font-medium text-text-100 transition-colors ${FORM_STYLES.hover.bg200}`}
       >
         <span>{selectedTab?.label || '전체'}</span>
-        <span className="rounded-full bg-bg-300 px-1.5 py-0.5 text-xs text-text-200">
-          {selectedTab?.count || 0}
-        </span>
         <ChevronDown className="h-4 w-4" />
       </button>
 
@@ -53,12 +51,7 @@ export function RefundStatusTabs({ summary, activeFilter, onFilterChange }: Refu
               }}
               className={`block w-full px-4 py-2 text-left text-sm text-text-100 first:rounded-t-lg last:rounded-b-lg ${FORM_STYLES.hover.bg200}`}
             >
-              <div className="flex items-center justify-between">
-                <span>{tab.label}</span>
-                <span className="rounded-full bg-bg-300 px-1.5 py-0.5 text-xs text-text-200">
-                  {tab.count}
-                </span>
-              </div>
+              <span>{tab.label}</span>
             </button>
           ))}
         </div>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,6 +21,7 @@ export { useImageCarousel } from './useImageCarousel';
 export { useAuthGuard } from './useAuthGuard';
 export { usePointHistory } from './usePointHistory';
 export { useOrders } from './useOrders';
+export { useRefunds } from './useRefunds';
 export { useInfiniteScroll } from './useInfiniteScroll';
 export * from './usePostcode';
 

--- a/src/hooks/useRefunds.ts
+++ b/src/hooks/useRefunds.ts
@@ -1,0 +1,121 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getRefunds } from '@/services/refundService';
+import { convertRefund } from '@/lib/utils';
+import { Refund, RefundStatusSummary, RefundStatusFilter, ApiRefund } from '@/types/refund';
+
+export function useRefunds(statusFilter: RefundStatusFilter = 'all') {
+  const [allRefunds, setAllRefunds] = useState<ApiRefund[]>([]);
+  const [refunds, setRefunds] = useState<Refund[]>([]);
+  const [summary, setSummary] = useState<RefundStatusSummary>({
+    approved: 0,
+    completed: 0,
+    rejected: 0,
+    failed: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [page, setPage] = useState(1);
+
+  // 초기 데이터 로드
+  const loadInitialData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const apiStatus = statusFilter;
+      const apiParams = {
+        status: apiStatus as 'all' | 'APPROVED' | 'COMPLETED' | 'REJECTED' | 'FAILED',
+        page: 1,
+        size: 5,
+      };
+
+      const data = await getRefunds(apiParams);
+      setAllRefunds(data.refunds);
+      const convertedRefunds = data.refunds.map(convertRefund);
+      setRefunds(convertedRefunds);
+
+      // 개수는 더 이상 사용하지 않음 (필터 탭에서 숨김)
+      setSummary({ approved: 0, completed: 0, rejected: 0, failed: 0 });
+
+      setPage(2);
+      setHasMore(data.refunds.length === 5);
+    } catch (err) {
+      console.error('환불 내역 조회 실패:', err);
+      setError(`에러: ${err instanceof Error ? err.message : '알 수 없는 오류'}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter]);
+
+  // 추가 데이터 로드 (무한 스크롤)
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !hasMore) {
+      return;
+    }
+
+    try {
+      setLoadingMore(true);
+
+      // 클라이언트 필터를 API 형식으로 변환 (이제 직접 매핑)
+      const apiStatus = statusFilter;
+
+      const data = await getRefunds({
+        status: apiStatus as 'all' | 'APPROVED' | 'COMPLETED' | 'REJECTED' | 'FAILED',
+        page,
+        size: 5,
+      });
+
+      // 데이터가 없거나 5개 미만이면 더 이상 없음
+      if (data.refunds.length === 0) {
+        setHasMore(false);
+        return;
+      }
+
+      if (data.refunds.length < 5) {
+        setHasMore(false);
+      }
+
+      // 기존 데이터에 새 데이터 추가 (함수형 업데이트)
+      setAllRefunds((prev) => {
+        const newAllRefunds = [...prev, ...data.refunds];
+        // 변환하여 UI 데이터 업데이트
+        const newConvertedRefunds = newAllRefunds.map(convertRefund);
+        setRefunds(newConvertedRefunds);
+
+        // 개수는 더 이상 사용하지 않음 (필터 탭에서 숨김)
+        setSummary({ approved: 0, completed: 0, rejected: 0, failed: 0 });
+
+        return newAllRefunds;
+      });
+
+      setPage((prev) => prev + 1);
+    } catch (err) {
+      console.error('추가 데이터 로드 실패:', err);
+      // 에러 발생시 더 이상 로드하지 않음
+      setHasMore(false);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [page, loadingMore, hasMore, statusFilter]);
+
+  // statusFilter가 변경되면 데이터 다시 로드
+  useEffect(() => {
+    setAllRefunds([]);
+    setRefunds([]);
+    setPage(1);
+    setHasMore(true);
+    loadInitialData();
+  }, [loadInitialData]);
+
+  return {
+    refunds,
+    summary,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    loadMore,
+  };
+}

--- a/src/hooks/useRefunds.ts
+++ b/src/hooks/useRefunds.ts
@@ -1,7 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getRefunds } from '@/services/refundService';
 import { convertRefund } from '@/lib/utils';
-import { Refund, RefundStatusSummary, RefundStatusFilter, ApiRefund } from '@/types/refund';
+import {
+  Refund,
+  RefundStatusSummary,
+  RefundStatusFilter,
+  ApiRefund,
+  ApiRefundsParams,
+} from '@/types/refund';
 
 export function useRefunds(statusFilter: RefundStatusFilter = 'all') {
   const [allRefunds, setAllRefunds] = useState<ApiRefund[]>([]);
@@ -25,8 +31,8 @@ export function useRefunds(statusFilter: RefundStatusFilter = 'all') {
       setError(null);
 
       const apiStatus = statusFilter;
-      const apiParams = {
-        status: apiStatus as 'all' | 'APPROVED' | 'COMPLETED' | 'REJECTED' | 'FAILED',
+      const apiParams: ApiRefundsParams = {
+        status: apiStatus,
         page: 1,
         size: 5,
       };
@@ -62,7 +68,7 @@ export function useRefunds(statusFilter: RefundStatusFilter = 'all') {
       const apiStatus = statusFilter;
 
       const data = await getRefunds({
-        status: apiStatus as 'all' | 'APPROVED' | 'COMPLETED' | 'REJECTED' | 'FAILED',
+        status: apiStatus,
         page,
         size: 5,
       });

--- a/src/lib/format-utils.ts
+++ b/src/lib/format-utils.ts
@@ -27,6 +27,21 @@ export const formatDate = (date: Date) => {
     .replace(/\./g, '.');
 };
 
+// 날짜 + 시간 포맷 함수 (YYYY.MM.DD HH:MM 형식)
+export const formatDateTime = (date: Date) => {
+  return date
+    .toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+    .replace(/\./g, '.')
+    .replace(/\s/g, ' ');
+};
+
 // 가격 포맷 함수 (천 단위 콤마)
 export const formatPrice = (price: number) => {
   return new Intl.NumberFormat('ko-KR').format(price);

--- a/src/services/refundService.ts
+++ b/src/services/refundService.ts
@@ -1,0 +1,48 @@
+import api from '@/lib/axios';
+import { ApiRefundsParams, ApiRefundsResponse } from '@/types/refund';
+
+const PAGE_SIZE = 5;
+
+// 클라이언트 status를 서버 형식으로 변환
+function convertStatusForServer(status: string): string {
+  const statusMap: Record<string, string> = {
+    all: 'all',
+    APPROVED: 'APPROVED',
+    REJECTED: 'REJECTED',
+    PENDING: 'PENDING',
+  };
+  return statusMap[status] || status;
+}
+
+// 환불 내역 조회
+export async function getRefunds(params: ApiRefundsParams = {}) {
+  const { status = 'all', page = 1, size = PAGE_SIZE } = params;
+
+  // 서버 형식으로 변환
+  const serverStatus = convertStatusForServer(status);
+
+  const requestParams = {
+    ...(status !== 'all' && { status: serverStatus }),
+    page,
+    size,
+  };
+
+  try {
+    const response = await api.get<{
+      success: boolean;
+      message: string;
+      data: ApiRefundsResponse;
+    }>('/refunds/my', {
+      params: requestParams,
+    });
+
+    if (!response.data.success) {
+      throw new Error(response.data.message || 'API 요청 실패');
+    }
+
+    return response.data.data;
+  } catch (error) {
+    console.error('환불 내역 조회 중 오류:', error);
+    throw error;
+  }
+}

--- a/src/types/refund.ts
+++ b/src/types/refund.ts
@@ -9,8 +9,13 @@ export interface RefundItem {
   refundAmount: number;
 }
 
-export type RefundType = 'CHANGE_OF_MIND' | 'DEFECTIVE_PRODUCT' | 'DELIVERY_ISSUE' | 'OTHER';
-export type RefundStatus = 'COMPLETED' | 'REJECTED'; // 신청됨/실패/승인 제거
+export type RefundType =
+  | 'CHANGE_OF_MIND'
+  | 'DEFECTIVE_PRODUCT'
+  | 'DELIVERY_ISSUE'
+  | 'GROUPBUY_FAIL'
+  | 'OTHER';
+export type RefundStatus = 'APPROVED' | 'COMPLETED' | 'REJECTED' | 'FAILED';
 export type RefundScope = 'FULL_ORDER' | 'INDIVIDUAL_GROUP_BUY'; // 전체 주문 환불 vs 개별 공구 환불
 
 export interface Refund {
@@ -33,27 +38,68 @@ export interface Refund {
 }
 
 export interface RefundStatusSummary {
+  approved: number;
   completed: number;
   rejected: number;
+  failed: number;
 }
 
-export type RefundStatusFilter = 'all' | 'COMPLETED' | 'REJECTED';
+export type RefundStatusFilter = 'all' | 'APPROVED' | 'COMPLETED' | 'REJECTED' | 'FAILED';
 
 export type RefundTypeFilter =
   | 'all'
   | 'CHANGE_OF_MIND'
   | 'DEFECTIVE_PRODUCT'
   | 'DELIVERY_ISSUE'
+  | 'GROUPBUY_FAIL'
   | 'OTHER';
+
+// API 응답 타입들
+export interface ApiRefundItem {
+  groupbuyOptionId: number;
+  productOptionId: number;
+  optionImage: string;
+  productName: string;
+  optionName: string;
+  quantity: number;
+  price: number;
+}
+
+export interface ApiRefund {
+  refundId: string;
+  createdAt: string;
+  type: 'GROUPBUY_FAILED' | 'CHANGE_OF_MIND' | 'DEFECTIVE_PRODUCT' | 'DELIVERY_ISSUE' | 'OTHER';
+  reason: string;
+  status: 'APPROVED' | 'REJECTED' | 'PENDING';
+  rejectionReason?: string; // API에서는 rejectionReason로 옴
+  refundAt?: string; // API에서는 refundAt로 옴
+  totalAmount: number;
+  refundItems: ApiRefundItem[];
+}
+
+export interface ApiRefundsResponse {
+  refunds: ApiRefund[];
+  page: number;
+  size: number;
+  total: number;
+}
+
+export interface ApiRefundsParams {
+  status?: 'all' | 'APPROVED' | 'COMPLETED' | 'REJECTED' | 'FAILED' | 'PENDING';
+  page?: number;
+  size?: number;
+}
 
 export const getRefundTypeLabel = (type: RefundType): string => {
   switch (type) {
     case 'CHANGE_OF_MIND':
       return '단순 변심';
     case 'DEFECTIVE_PRODUCT':
-      return '하자/오배송';
+      return '불량품';
     case 'DELIVERY_ISSUE':
       return '배송 문제';
+    case 'GROUPBUY_FAIL':
+      return '공구 실패';
     case 'OTHER':
       return '기타';
     default:
@@ -63,10 +109,14 @@ export const getRefundTypeLabel = (type: RefundType): string => {
 
 export const getRefundStatusLabel = (status: RefundStatus): string => {
   switch (status) {
+    case 'APPROVED':
+      return '환불 승인';
     case 'COMPLETED':
       return '환불 완료';
     case 'REJECTED':
       return '환불 거절';
+    case 'FAILED':
+      return '환불 실패';
     default:
       return '알 수 없음';
   }


### PR DESCRIPTION
## ⭐️ Issue Number
- #99 

## 🚩 Summary
- 환불 내역 페이지 실제 API 연동 구현
- 환불 상태 필터에 `APPROVED`, `FAILED` 상태 추가
- 공구 실패 자동 환불과 수동 환불 구분 표시
- 기존 무한 스크롤 시스템 적용하여 페이지네이션 구현

## 🛠️ Technical Concerns

### 1. 환불 내역 API 연동 (`GET /api/refunds/my`)
- **API 서비스 신규 추가**: `src/services/refundService.ts`
  - 상태별 필터링 파라미터 지원 (`status`, `page`, `size`)
  - 서버 응답을 클라이언트 타입으로 변환하는 매핑 로직
  - 에러 처리 및 기본값 설정

### 2. 환불 상태 필터 확장
- **기존 상태**: `COMPLETED`, `REJECTED`
- **추가 상태**: `APPROVED`, `FAILED`
- **UI 컴포넌트 업데이트**:
  - `StatusBadge.tsx`: 새로운 상태 라벨 및 스타일링 추가
  - `RefundStatusTabs.tsx`: 5개 필터 탭으로 확장, 개수 표시 제거

### 3. 무한 스크롤 적용
- 기존 `useInfiniteScroll` 훅 활용하여 페이지네이션 구현
- 초기 로드 5개, 추가 로드 시 5개씩 가져오기
- 상태별 필터 변경 시 데이터 초기화 및 재로드
- 로딩 상태 관리 (`loading`, `loadingMore`)

## 🙂 To Reviewer
- 환불 상태 필터 확장이 사용자에게 더 명확한 정보 제공하는지 UX 관점에서 검토 요청
- 목업 데이터에서 실제 API 데이터로 전환 시 데이터 구조 차이로 인한 잠재적 버그 가능성 확인 요청

## 📸 첨부 이미지
- 취소/환불 내역
<img width="500"  alt="취소/환불 내역" src="https://github.com/user-attachments/assets/e550b49f-067f-4006-8d00-78059cbb2cc8" />

## 📋 To Do
- [ ] 장바구니 API 연동
- [ ] 결제 API 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 환불 목록에 무한 스크롤과 상태별 필터링 기능이 도입되었습니다.
  * 환불 상태 탭에 '승인됨(APPROVED)'과 '실패(FAILED)' 상태가 추가되었습니다.
  * 환불 사유에 '공구 실패(GROUPBUY_FAIL)' 유형이 새롭게 포함되었습니다.

* **개선 사항**
  * 환불 목록과 상태 요약, 로딩 및 에러 표시가 더욱 직관적이고 동적으로 개선되었습니다.
  * 환불 카드에서 환불 승인일, 실패일 등 다양한 상태별 날짜 정보가 표시됩니다.
  * 상태 뱃지가 '승인됨'과 '실패' 등 신규 상태를 지원하며, 디자인이 반영되었습니다.

* **버그 수정**
  * 환불 사유 및 상태 라벨이 최신 정책과 신규 상태에 맞게 정확히 표시됩니다.

* **기타**
  * 환불 관련 API 연동, 데이터 포맷 및 변환 로직이 개선되어 일관된 정보 제공이 가능합니다.
  * 환불 데이터 조회를 위한 신규 서비스 및 훅이 추가되었습니다.
  * 날짜 및 시간 포맷 함수가 추가되어 표시 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->