### PR TITLE
공동구매 판매자용 목록 조회 및 공동구매 상태 변경 API 연동

### DIFF
--- a/src/app/groupbuys/[id]/page.tsx
+++ b/src/app/groupbuys/[id]/page.tsx
@@ -52,10 +52,10 @@ export default function GroupBuyDetailPage({ params }: GroupBuyDetailPageProps) 
 
     // 할인 단계를 rewardTiers로 변환 (실제 달성 여부만 반영)
     const rewardTiers = groupBuy.discountStages.map((stage) => ({
-      participants: stage.minQuantity,
-      discount: `${stage.discountRate}% 할인`,
-      discountRate: stage.discountRate, // 숫자형 할인율 추가
-      achieved: groupBuy.currentOrderCount >= stage.minQuantity,
+      participants: stage.count,
+      discount: `${stage.rate}% 할인`,
+      discountRate: stage.rate, // 숫자형 할인율 추가
+      achieved: groupBuy.currentOrderCount >= stage.count,
     }));
 
     // productNotice 정보를 Product 타입 필드로 매핑
@@ -86,7 +86,7 @@ export default function GroupBuyDetailPage({ params }: GroupBuyDetailPageProps) 
       discountRate: groupBuy.maxDiscountRate,
       point: 0, // API에 point 정보가 없으므로 0으로 설정
       participants: groupBuy.currentOrderCount,
-      targetParticipants: groupBuy.discountStages[0]?.minQuantity || 0,
+      targetParticipants: groupBuy.discountStages[0]?.count || 0,
       remainingDays,
       category: {
         main: groupBuy.product.categoryIds[0] || 'general',

--- a/src/app/groupbuys/[id]/page.tsx
+++ b/src/app/groupbuys/[id]/page.tsx
@@ -121,8 +121,11 @@ export default function GroupBuyDetailPage({ params }: GroupBuyDetailPageProps) 
 
         const response = await getGroupBuyDetail(groupBuyId);
         setGroupBuyData(response.data);
-      } catch (err: any) {
-        setError(err.message || '공동구매 정보를 불러오는데 실패했습니다.');
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+        setError(errorMessage || '공동구매 정보를 불러오는데 실패했습니다.');
+        // TODO: 에러 로깅 서비스 연동
+        console.error('공구상세 정보 조회 실패:', err);
       } finally {
         setIsLoading(false);
       }

--- a/src/app/mypage/address/page.tsx
+++ b/src/app/mypage/address/page.tsx
@@ -97,7 +97,7 @@ function AddressListPageContent() {
 
         {/* 배송지 리스트 */}
         <div className="flex flex-col gap-4">
-          {addresses.length === 0 ? (
+          {!addresses || addresses.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8">
               <p className="text-center text-text-300">등록된 배송지가 없습니다.</p>
             </div>

--- a/src/app/seller/group-buys/page.tsx
+++ b/src/app/seller/group-buys/page.tsx
@@ -1,7 +1,17 @@
 'use client';
 
-import { EmptyPage } from '@/components/seller/common';
+import { AuthGuard } from '@/components/auth/AuthGuard';
+import { GroupBuyManagement } from '@/components/seller/GroupBuyManagement';
 
-export default function GroupBuyPage() {
-  return <EmptyPage title="준비중이에요" />;
+// 인증된 판매자만 접근할 수 있는 그룹바이 관리 컴포넌트
+function AuthenticatedGroupBuyManagement() {
+  return <GroupBuyManagement />;
+}
+
+export default function GroupBuysPage() {
+  return (
+    <AuthGuard requireAuth requireSeller>
+      <AuthenticatedGroupBuyManagement />
+    </AuthGuard>
+  );
 }

--- a/src/components/home/ProductRankingItem.tsx
+++ b/src/components/home/ProductRankingItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import type { Product } from '@/types/product';
 
 interface ProductRankingItemProps {
@@ -12,44 +13,46 @@ export function ProductRankingItem({ product, index, variant }: ProductRankingIt
   const isMobile = variant === 'mobile';
 
   return (
-    <div
-      className={`flex items-center rounded-xl bg-bg-100 ${isMobile ? 'gap-3' : 'flex-1 gap-4'}`}
-    >
-      {/* 랭킹 번호 */}
+    <Link href={`/groupbuys/${product.id}`} className="block">
       <div
-        className={`flex flex-shrink-0 items-center justify-center text-lg font-bold text-text-100 ${
-          isMobile ? 'h-8 w-4' : 'h-10 w-5'
-        }`}
+        className={`flex items-center rounded-xl bg-bg-100 ${isMobile ? 'gap-3' : 'flex-1 gap-4'}`}
       >
-        {index + 1}
-      </div>
-
-      {/* 상품 이미지 */}
-      <div
-        className={`relative flex-shrink-0 overflow-hidden rounded-lg ${
-          isMobile ? 'h-14 w-14' : 'h-20 w-20'
-        }`}
-      >
-        <Image src={product.mainImage} alt={product.name} fill className="object-cover" />
-      </div>
-
-      {/* 상품 정보 */}
-      <div className="min-w-0 flex-1">
-        {/* 마감 문구 */}
-        <div className="mb-1 inline-block rounded-md bg-primary-100 px-3 py-1 text-xs font-medium text-primary-300">
-          공구 마감까지 {product.remainingDays}일 남았어요!
+        {/* 랭킹 번호 */}
+        <div
+          className={`flex flex-shrink-0 items-center justify-center text-lg font-bold text-text-100 ${
+            isMobile ? 'h-8 w-4' : 'h-10 w-5'
+          }`}
+        >
+          {index + 1}
         </div>
-        <h3 className="mb-1 line-clamp-2 text-sm font-medium text-text-100">{product.name}</h3>
-        <div className="flex items-center gap-2">
-          <span className="text-lg font-bold text-primary-300">{product.discountRate}%</span>
-          <span className="text-sm text-text-300 line-through">
-            {product.originalPrice.toLocaleString()}원
-          </span>
-          <span className="text-lg font-bold text-text-100">
-            {product.price.toLocaleString()}원
-          </span>
+
+        {/* 상품 이미지 */}
+        <div
+          className={`relative flex-shrink-0 overflow-hidden rounded-lg ${
+            isMobile ? 'h-14 w-14' : 'h-20 w-20'
+          }`}
+        >
+          <Image src={product.mainImage} alt={product.name} fill className="object-cover" />
+        </div>
+
+        {/* 상품 정보 */}
+        <div className="min-w-0 flex-1">
+          {/* 마감 문구 */}
+          <div className="mb-1 inline-block rounded-md bg-primary-100 px-3 py-1 text-xs font-medium text-primary-300">
+            공구 마감까지 {product.remainingDays}일 남았어요!
+          </div>
+          <h3 className="mb-1 line-clamp-2 text-sm font-medium text-text-100">{product.name}</h3>
+          <div className="flex items-center gap-2">
+            <span className="text-lg font-bold text-primary-300">{product.discountRate}%</span>
+            <span className="text-sm text-text-300 line-through">
+              {product.originalPrice.toLocaleString()}원
+            </span>
+            <span className="text-lg font-bold text-text-100">
+              {product.price.toLocaleString()}원
+            </span>
+          </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/components/seller/GroupBuyManagement.tsx
+++ b/src/components/seller/GroupBuyManagement.tsx
@@ -59,8 +59,11 @@ export function GroupBuyManagement() {
       const data = await getSellerGroupBuys(page, pageSize);
       setGroupBuyData(data);
       setAllGroupBuys(data.data.content || []);
-    } catch (err: any) {
-      setError(err.message || '공구 목록을 불러오는데 실패했습니다.');
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+      setError(errorMessage || '공구 목록을 불러오는데 실패했습니다.');
+      // TODO: 에러 로깅 서비스 연동
+      console.error('공구 목록 조회 실패:', err);
     } finally {
       setIsLoading(false);
     }
@@ -109,11 +112,12 @@ export function GroupBuyManagement() {
       // 삭제 후 목록 새로고침
       await fetchGroupBuys(currentPage);
       setDeleteConfirm({ isOpen: false, groupBuyId: null, groupBuyTitle: '' });
-    } catch (error: any) {
-      console.error('Delete failed:', error);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+      console.error('공구 삭제 실패:', err);
       setDeleteError({
         isOpen: true,
-        message: `"${groupBuyTitle}" ${error.message || '그룹바이 삭제에 실패했습니다.'}`,
+        message: `"${groupBuyTitle}" ${errorMessage || '그룹바이 삭제에 실패했습니다.'}`,
       });
       setDeleteConfirm({ isOpen: false, groupBuyId: null, groupBuyTitle: '' });
     }
@@ -138,9 +142,10 @@ export function GroupBuyManagement() {
       await updateGroupBuyStatus(startConfirm.groupBuyId, 'OPEN');
       await fetchGroupBuys(currentPage);
       setStartConfirm({ isOpen: false, groupBuyId: null, groupBuyTitle: '' });
-    } catch (error: any) {
-      console.error('공구 시작 실패:', error);
-      setError('공구 시작에 실패했습니다.');
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+      console.error('공구 시작 실패:', err);
+      setError(errorMessage || '공구 시작에 실패했습니다.');
       setStartConfirm({ isOpen: false, groupBuyId: null, groupBuyTitle: '' });
     }
   };

--- a/src/components/seller/GroupBuyManagement.tsx
+++ b/src/components/seller/GroupBuyManagement.tsx
@@ -194,7 +194,25 @@ export function GroupBuyManagement() {
   const totalCount = allGroupBuys.length;
 
   if (error) {
-    return <div className="py-20 text-center text-red-500">서버 오류가 발생했습니다.</div>;
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-10 md:px-0">
+        <h1 className="mb-10 text-center text-3xl font-semibold text-text-100">공구 관리</h1>
+        <div className="space-y-6">
+          <EmptyState
+            icon="🤝"
+            title="등록된 공구가 없습니다"
+            description="첫 번째 공구를 등록해보세요"
+          />
+          <div className="text-center">
+            <Button onClick={handleRegisterGroupBuy} className={FORM_STYLES.button.submit}>
+              <Plus className="mr-2 h-4 w-4" />
+              공구 등록하기
+            </Button>
+          </div>
+        </div>
+        <ScrollToTopButton />
+      </div>
+    );
   }
   if (isLoading) {
     return (

--- a/src/components/seller/GroupBuyManagement.tsx
+++ b/src/components/seller/GroupBuyManagement.tsx
@@ -23,6 +23,7 @@ import { Badge } from '@/components/ui/badge';
 export function GroupBuyManagement() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingCounts, setIsLoadingCounts] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [groupBuyData, setGroupBuyData] = useState<SellerGroupBuyListResponse | null>(null);
   const [allGroupBuys, setAllGroupBuys] = useState<SellerGroupBuy[]>([]);
@@ -58,7 +59,6 @@ export function GroupBuyManagement() {
     try {
       const data = await getSellerGroupBuys(page, pageSize);
       setGroupBuyData(data);
-      setAllGroupBuys(data.data.content || []);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
       setError(errorMessage || '공구 목록을 불러오는데 실패했습니다.');
@@ -69,8 +69,23 @@ export function GroupBuyManagement() {
     }
   };
 
+  // 전체 그룹바이 목록 조회 (카운트용)
+  const fetchAllGroupBuys = async () => {
+    setIsLoadingCounts(true);
+    try {
+      const data = await getAllSellerGroupBuys();
+      setAllGroupBuys(data.data.content || []);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+      console.error('전체공구 목록 조회 실패:', err);
+    } finally {
+      setIsLoadingCounts(false);
+    }
+  };
+
   useEffect(() => {
     fetchGroupBuys(currentPage);
+    fetchAllGroupBuys();
   }, [currentPage]);
 
   const handleRefresh = () => {
@@ -111,6 +126,7 @@ export function GroupBuyManagement() {
 
       // 삭제 후 목록 새로고침
       await fetchGroupBuys(currentPage);
+      await fetchAllGroupBuys(); // 전체 카운트도 새로고침
       setDeleteConfirm({ isOpen: false, groupBuyId: null, groupBuyTitle: '' });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
@@ -141,6 +157,7 @@ export function GroupBuyManagement() {
     try {
       await updateGroupBuyStatus(startConfirm.groupBuyId, 'OPEN');
       await fetchGroupBuys(currentPage);
+      await fetchAllGroupBuys(); // 전체 카운트도 새로고침
       setStartConfirm({ isOpen: false, groupBuyId: null, groupBuyTitle: '' });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';

--- a/src/components/seller/GroupBuyManagement.tsx
+++ b/src/components/seller/GroupBuyManagement.tsx
@@ -187,6 +187,11 @@ export function GroupBuyManagement() {
   const isFirst = groupBuyData?.data?.first || true;
   const isLast = groupBuyData?.data?.last || true;
 
+  // 최신순으로 정렬 (updatedAt 기준)
+  const sortedGroupBuys = [...groupBuys].sort((a, b) => {
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+
   // 전체 데이터에서 카운트 계산
   const openCount = allGroupBuys.filter((g) => g.status === 'OPEN').length;
   const draftCount = allGroupBuys.filter((g) => g.status === 'DRAFT').length;
@@ -288,7 +293,7 @@ export function GroupBuyManagement() {
                 msOverflowStyle: 'none',
               }}
             >
-              {groupBuys.map((groupBuy) => (
+              {sortedGroupBuys.map((groupBuy) => (
                 <Card key={groupBuy.id} className={FORM_STYLES.card.seller}>
                   <CardContent className="relative p-6">
                     {/* 상태 뱃지: 우측 상단 고정 */}

--- a/src/components/seller/GroupBuyManagement.tsx
+++ b/src/components/seller/GroupBuyManagement.tsx
@@ -50,7 +50,7 @@ export function GroupBuyManagement() {
       setGroupBuyData(data);
       setAllGroupBuys(data.data.content || []);
     } catch (err: any) {
-      setError(err.message || '그룹바이 목록을 불러오는데 실패했습니다.');
+      setError(err.message || '공구 목록을 불러오는데 실패했습니다.');
     } finally {
       setIsLoading(false);
     }
@@ -170,8 +170,8 @@ export function GroupBuyManagement() {
 
   // 전체 데이터에서 카운트 계산
   const openCount = allGroupBuys.filter((g) => g.status === 'OPEN').length;
+  const draftCount = allGroupBuys.filter((g) => g.status === 'DRAFT').length;
   const closedCount = allGroupBuys.filter((g) => g.status === 'CLOSED').length;
-  const completedCount = allGroupBuys.filter((g) => g.status === 'COMPLETED').length;
   const totalCount = allGroupBuys.length;
 
   if (error) {
@@ -180,7 +180,7 @@ export function GroupBuyManagement() {
   if (isLoading) {
     return (
       <div className="mx-auto max-w-3xl px-4 py-10 md:px-0">
-        <h1 className="mb-10 text-center text-3xl font-semibold text-text-100">그룹바이 관리</h1>
+        <h1 className="mb-10 text-center text-3xl font-semibold text-text-100">공구 관리</h1>
         <div className="space-y-4">
           {Array.from({ length: 3 }).map((_, index) => (
             <LoadingSkeleton key={index} className="h-24 w-full" />
@@ -194,7 +194,7 @@ export function GroupBuyManagement() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-10 md:px-0">
       {/* 타이틀 */}
-      <h1 className="mb-10 text-center text-3xl font-semibold text-text-100">그룹바이 관리</h1>
+      <h1 className="mb-10 text-center text-3xl font-semibold text-text-100">공구 관리</h1>
 
       {/* 상단 카운트 4개 */}
       <div className="mx-auto mb-10 flex w-full max-w-lg justify-center">
@@ -207,38 +207,38 @@ export function GroupBuyManagement() {
         <div className="flex flex-1 flex-col items-center">
           <span className="text-2xl font-bold text-text-100 md:text-4xl">{openCount}</span>
           <span className="mt-1 text-center text-sm font-medium text-text-200 md:text-lg">
-            진행중
+            공구 진행중
+          </span>
+        </div>
+        <div className="flex flex-1 flex-col items-center">
+          <span className="text-2xl font-bold text-text-100 md:text-4xl">{draftCount}</span>
+          <span className="mt-1 text-center text-sm font-medium text-text-200 md:text-lg">
+            공구 대기
           </span>
         </div>
         <div className="flex flex-1 flex-col items-center">
           <span className="text-2xl font-bold text-text-100 md:text-4xl">{closedCount}</span>
           <span className="mt-1 text-center text-sm font-medium text-text-200 md:text-lg">
-            마감됨
-          </span>
-        </div>
-        <div className="flex flex-1 flex-col items-center">
-          <span className="text-2xl font-bold text-text-100 md:text-4xl">{completedCount}</span>
-          <span className="mt-1 text-center text-sm font-medium text-text-200 md:text-lg">
-            완료됨
+            공구 마감
           </span>
         </div>
       </div>
 
-      {/* 그룹바이 목록 섹션 */}
+      {/* 공구 목록 섹션 */}
       <section>
-        <SectionHeader title="등록된 그룹바이" />
+        <SectionHeader title="등록된 공구" />
         <div className="mt-4">
           {groupBuys.length === 0 ? (
             <div className="space-y-6">
               <EmptyState
                 icon="🤝"
-                title="등록된 그룹바이가 없습니다"
-                description="첫 번째 그룹바이를 등록해보세요"
+                title="등록된 공구가 없습니다"
+                description="첫 번째 공구를 등록해보세요"
               />
               <div className="text-center">
                 <Button onClick={handleRegisterGroupBuy} className={FORM_STYLES.button.submit}>
                   <Plus className="mr-2 h-4 w-4" />
-                  그룹바이 등록하기
+                  공구 등록하기
                 </Button>
               </div>
             </div>
@@ -325,7 +325,7 @@ export function GroupBuyManagement() {
         </div>
       </section>
 
-      {/* 페이지네이션: 그룹바이 관리 페이지 하단 */}
+      {/* 페이지네이션: 공구 관리 페이지 하단 */}
       {totalPages > 1 && (
         <div className="mt-12">
           <Pagination
@@ -344,8 +344,8 @@ export function GroupBuyManagement() {
         isOpen={deleteConfirm.isOpen}
         onClose={handleDeleteCancel}
         onConfirm={handleDeleteConfirm}
-        title="그룹바이 삭제 확인"
-        message={`"${deleteConfirm.groupBuyTitle}"\n\n그룹바이를 삭제하시겠습니까? 삭제하면 복구가 불가능합니다.`}
+        title="공구 삭제 확인"
+        message={`"${deleteConfirm.groupBuyTitle}"\n\n공구를 삭제하시겠습니까? 삭제하면 복구가 불가능합니다.`}
         confirmText="삭제하기"
         cancelText="취소"
         variant="danger"
@@ -355,7 +355,7 @@ export function GroupBuyManagement() {
       <ErrorDialog
         isOpen={deleteError.isOpen}
         onClose={() => setDeleteError({ isOpen: false, message: '' })}
-        title="그룹바이 삭제 실패"
+        title="공구 삭제 실패"
         message={deleteError.message}
       />
     </div>

--- a/src/components/seller/GroupBuyRegistration.tsx
+++ b/src/components/seller/GroupBuyRegistration.tsx
@@ -420,8 +420,8 @@ export function GroupBuyForm({ mode, initialData, onSubmit }: GroupBuyFormProps)
       limitQuantityPerMember: maxQuantityPerPerson,
       productId: Number(selectedProductId),
       discountStages: discountTiers.map((tier) => ({
-        minQuantity: tier.minParticipants,
-        discountRate: tier.discountRate,
+        count: tier.minParticipants,
+        rate: tier.discountRate,
       })),
       options:
         selectedProduct?.options

--- a/src/components/seller/GroupBuyRegistration.tsx
+++ b/src/components/seller/GroupBuyRegistration.tsx
@@ -260,17 +260,20 @@ export function GroupBuyForm({ mode, initialData, onSubmit }: GroupBuyFormProps)
         setError(null);
         const response = await fetchGroupBuyCreateData();
         setProducts(response.data.products);
-      } catch (err: any) {
-        // 409 에러나 상품이 없다는 에러는 EmptyState로 처리
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+        // 49 상품이 없다는 에러는 EmptyState로 처리
         if (
-          err.message?.includes('공동구매 등록 가능한 상품 없습니다') ||
-          err.message?.includes('상품이 없습니다') ||
-          err.status === 409
+          errorMessage?.includes('공동구매 등록 가능한 상품 없습니다') ||
+          errorMessage?.includes('상품이 없습니다') ||
+          (err as any)?.status === 409
         ) {
           setProducts([]); // 빈 배열로 설정하여 EmptyState 표시
         } else {
-          setError(err.message || '상품 데이터를 불러오지 못했습니다.');
+          setError(errorMessage || '상품 데이터를 불러오지 못했습니다.');
         }
+        // TODO: 에러 로깅 서비스 연동
+        console.error('상품 데이터 로드 실패:', err);
       } finally {
         setIsLoading(false);
       }
@@ -451,8 +454,11 @@ export function GroupBuyForm({ mode, initialData, onSubmit }: GroupBuyFormProps)
         await createGroupBuy({ request, thumbnail, detailImages });
         setSubmitSuccess('공동구매가 성공적으로 등록되었습니다!');
         // TODO: 등록 후 이동 (예: 라우터 push)
-      } catch (err: any) {
-        setSubmitError(err?.message || '공동구매 등록에 실패했습니다.');
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+        setSubmitError(errorMessage || '공동구매 등록에 실패했습니다.');
+        // TODO: 에러 로깅 서비스 연동
+        console.error('공구 등록 실패:', err);
       } finally {
         setIsSubmitting(false);
       }

--- a/src/components/seller/GroupBuyRegistration.tsx
+++ b/src/components/seller/GroupBuyRegistration.tsx
@@ -220,7 +220,11 @@ export function GroupBuyForm({ mode, initialData, onSubmit }: GroupBuyFormProps)
   const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
 
   const handleErrorDialogClose = () => setSubmitError(null);
-  const handleSuccessDialogClose = () => setSubmitSuccess(null);
+  const handleSuccessDialogClose = () => {
+    setSubmitSuccess(null);
+    // 성공 모달창에서 확인 버튼을 누르면 공구 관리 페이지로 이동
+    router.push('/seller/group-buys');
+  };
 
   // 상품 1개만 선택
   const [selectedProductId, setSelectedProductId] = useState(initialData?.selectedProductId || '');

--- a/src/components/seller/index.ts
+++ b/src/components/seller/index.ts
@@ -1,6 +1,7 @@
 export { ProductRegistration } from './ProductRegistration';
 export { ProductEdit } from './ProductEdit';
 export { GroupBuyRegistration } from './GroupBuyRegistration';
+export { GroupBuyManagement } from './GroupBuyManagement';
 export { SellerSidebar } from './SellerSidebar';
 export { ProductManagement } from './ProductManagement';
 export { ProductDetail } from './ProductDetail';

--- a/src/hooks/useAddressList.ts
+++ b/src/hooks/useAddressList.ts
@@ -11,8 +11,8 @@ export function useAddressList() {
     try {
       setLoading(true);
       setError(null);
-      const response = await getShippingAddresses();
-      setAddresses(response.data || []);
+      const data = await getShippingAddresses();
+      setAddresses(data || []);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
       setError(errorMessage || '주소 목록을 불러오는데 실패했습니다.');

--- a/src/hooks/useAddressList.ts
+++ b/src/hooks/useAddressList.ts
@@ -11,11 +11,13 @@ export function useAddressList() {
     try {
       setLoading(true);
       setError(null);
-      const data = await getShippingAddresses();
-      setAddresses(data.addresses);
-    } catch (err: any) {
-      console.error('배송지 조회 오류:', err);
-      setError('배송지 조회 중 오류가 발생했습니다.');
+      const response = await getShippingAddresses();
+      setAddresses(response.data);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 알수 없는 오류가 발생했습니다';
+      setError(errorMessage || '주소 목록을 불러오는데 실패했습니다.);
+      // TODO: 에러 로깅 서비스 연동
+      console.error('주소 목록 조회 실패:', err);
     } finally {
       setLoading(false);
     }

--- a/src/hooks/useAddressList.ts
+++ b/src/hooks/useAddressList.ts
@@ -12,12 +12,13 @@ export function useAddressList() {
       setLoading(true);
       setError(null);
       const response = await getShippingAddresses();
-      setAddresses(response.data);
+      setAddresses(response.data || []);
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 알수 없는 오류가 발생했습니다';
-      setError(errorMessage || '주소 목록을 불러오는데 실패했습니다.);
+      const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+      setError(errorMessage || '주소 목록을 불러오는데 실패했습니다.');
       // TODO: 에러 로깅 서비스 연동
       console.error('주소 목록 조회 실패:', err);
+      setAddresses([]); // 에러 시 빈 배열로 설정
     } finally {
       setLoading(false);
     }

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -37,14 +37,11 @@ export const useCart = () => {
       } else {
         setError('장바구니를 불러오는데 실패했습니다.');
       }
-    } catch (err: any) {
-      const errorMessage = '장바구니를 불러오는데 실패했습니다.';
-      setError(errorMessage);
-      setErrorDialog({
-        isOpen: true,
-        title: '장바구니 조회 실패',
-        message: errorMessage,
-      });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알수 없는 오류가 발생했습니다';
+      setError(errorMessage || '장바구니를 불러오는데 실패했습니다.');
+      // TODO: 에러 로깅 서비스 연동
+      console.error('장바구니 조회 실패:', err);
     } finally {
       setIsLoading(false);
     }

--- a/src/hooks/usePayment.ts
+++ b/src/hooks/usePayment.ts
@@ -23,8 +23,8 @@ export const usePaymentRequest = () => {
       console.log('결제 요청 생성 성공:', response);
 
       return response;
-    } catch (err: any) {
-      const errorMessage = err.message || '결제 요청 생성에 실패했습니다.';
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.';
       setError(errorMessage);
       console.error('결제 요청 생성 실패:', err);
       throw err;
@@ -55,8 +55,8 @@ export const usePaymentSuccess = () => {
       console.log('결제 성공 처리 완료:', response);
 
       return response;
-    } catch (err: any) {
-      const errorMessage = err.message || '결제 성공 처리에 실패했습니다.';
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.';
       setError(errorMessage);
       console.error('결제 성공 처리 실패:', err);
       throw err;
@@ -95,8 +95,8 @@ export const usePaymentConfirm = () => {
       console.log('결제 승인 완료:', response);
 
       return response;
-    } catch (err: any) {
-      const errorMessage = err.message || '결제 승인에 실패했습니다.';
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.';
       setError(errorMessage);
       console.error('결제 승인 실패:', err);
       throw err;
@@ -127,8 +127,8 @@ export const usePaymentStatus = () => {
       console.log('결제 상태 조회 완료:', response);
 
       return response;
-    } catch (err: any) {
-      const errorMessage = err.message || '결제 상태 조회에 실패했습니다.';
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.';
       setError(errorMessage);
       console.error('결제 상태 조회 실패:', err);
       throw err;

--- a/src/services/groupbuyService.ts
+++ b/src/services/groupbuyService.ts
@@ -8,6 +8,7 @@ import type {
   GroupBuyCreateApiResponse,
   GroupBuyDetailResponse,
   GroupBuyDetail,
+  SellerGroupBuyListResponse,
 } from '@/types/groupbuy';
 import { Suspense } from 'react';
 
@@ -92,8 +93,8 @@ export async function getGroupBuyDetail(groupBuyId: number): Promise<GroupBuyDet
 // 공동구매 상태 변경 API
 export async function updateGroupBuyStatus(
   groupBuyId: number,
-  status: 'OPEN' | 'CLOSED' | 'ACTIVE',
-): Promise<any> {
+  status: 'OPEN' | 'CLOSED' | 'DRAFT',
+): Promise<{ success: boolean; message: string; data: any }> {
   console.log('상태 변경 API 호출:', { groupBuyId, status });
   const res = await api.patch(`/groupbuys/${groupBuyId}/status`, { status });
   console.log('상태 변경 API 응답:', res.data);
@@ -101,19 +102,24 @@ export async function updateGroupBuyStatus(
 }
 
 // 판매자 그룹바이 목록 조회 API
-export async function getSellerGroupBuys(page: number = 0, size: number = 10): Promise<any> {
+export async function getSellerGroupBuys(
+  page: number = 0,
+  size: number = 10,
+): Promise<SellerGroupBuyListResponse> {
   const res = await api.get(`/groupbuys/seller?page=${page}&size=${size}`);
   return res.data;
 }
 
 // 판매자 전체 그룹바이 목록 조회 API (카운트용)
-export async function getAllSellerGroupBuys(): Promise<any> {
+export async function getAllSellerGroupBuys(): Promise<SellerGroupBuyListResponse> {
   const res = await api.get('/groupbuys/seller');
   return res.data;
 }
 
 // 그룹바이 삭제 API
-export async function deleteGroupBuy(groupBuyId: number): Promise<any> {
+export async function deleteGroupBuy(
+  groupBuyId: number,
+): Promise<{ success: boolean; message: string }> {
   const res = await api.delete(`/groupbuys/${groupBuyId}`);
   return res.data;
 }

--- a/src/services/groupbuyService.ts
+++ b/src/services/groupbuyService.ts
@@ -88,3 +88,32 @@ export async function getGroupBuyDetail(groupBuyId: number): Promise<GroupBuyDet
   console.log('Raw API Response:', response);
   return response.data;
 }
+
+// 공동구매 상태 변경 API
+export async function updateGroupBuyStatus(
+  groupBuyId: number,
+  status: 'OPEN' | 'CLOSED' | 'ACTIVE',
+): Promise<any> {
+  console.log('상태 변경 API 호출:', { groupBuyId, status });
+  const res = await api.patch(`/groupbuys/${groupBuyId}/status`, { status });
+  console.log('상태 변경 API 응답:', res.data);
+  return res.data;
+}
+
+// 판매자 그룹바이 목록 조회 API
+export async function getSellerGroupBuys(page: number = 0, size: number = 10): Promise<any> {
+  const res = await api.get(`/groupbuys/seller?page=${page}&size=${size}`);
+  return res.data;
+}
+
+// 판매자 전체 그룹바이 목록 조회 API (카운트용)
+export async function getAllSellerGroupBuys(): Promise<any> {
+  const res = await api.get('/groupbuys/seller');
+  return res.data;
+}
+
+// 그룹바이 삭제 API
+export async function deleteGroupBuy(groupBuyId: number): Promise<any> {
+  const res = await api.delete(`/groupbuys/${groupBuyId}`);
+  return res.data;
+}

--- a/src/types/groupbuy.ts
+++ b/src/types/groupbuy.ts
@@ -57,8 +57,8 @@ export interface GroupBuyOptionRequest {
 }
 
 export interface GroupBuyDiscountStage {
-  minQuantity: number;
-  discountRate: number;
+  count: number;
+  rate: number;
 }
 
 export interface GroupBuyImageRequest {

--- a/src/types/groupbuy.ts
+++ b/src/types/groupbuy.ts
@@ -160,3 +160,54 @@ export interface GroupBuyDetailResponse {
   message: string;
   data: GroupBuyDetail;
 }
+
+// 판매자 그룹바이 목록 관련 타입
+export interface SellerGroupBuy {
+  id: number;
+  title: string;
+  thumbnailUrl: string;
+  displayFinalPrice: number;
+  startPrice: number;
+  maxDiscountRate: number;
+  status: 'OPEN' | 'CLOSED' | 'COMPLETED';
+  startAt: string;
+  endsAt: string;
+  totalStock: number;
+  soldQuantity: number;
+  orderCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SellerGroupBuyListResponse {
+  success: boolean;
+  message: string;
+  data: {
+    content: SellerGroupBuy[];
+    totalElements: number;
+    totalPages: number;
+    size: number;
+    number: number;
+    first: boolean;
+    last: boolean;
+    numberOfElements: number;
+    empty: boolean;
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    pageable: {
+      offset: number;
+      sort: {
+        empty: boolean;
+        sorted: boolean;
+        unsorted: boolean;
+      };
+      pageNumber: number;
+      pageSize: number;
+      paged: boolean;
+      unpaged: boolean;
+    };
+  };
+}

--- a/src/types/groupbuy.ts
+++ b/src/types/groupbuy.ts
@@ -144,7 +144,7 @@ export interface GroupBuyDetail {
   maxDiscountRate: number;
   discountStages: GroupBuyDiscountStage[];
   limitQuantityPerMember: number;
-  status: 'OPEN' | 'CLOSED' | 'COMPLETED';
+  status: 'OPEN' | 'CLOSED' | 'DRAFT';
   endsAt: string;
   currentOrderCount: number;
   product: GroupBuyProductDetail;
@@ -169,7 +169,7 @@ export interface SellerGroupBuy {
   displayFinalPrice: number;
   startPrice: number;
   maxDiscountRate: number;
-  status: 'OPEN' | 'CLOSED' | 'COMPLETED';
+  status: 'OPEN' | 'CLOSED' | 'DRAFT';
   startAt: string;
   endsAt: string;
   totalStock: number;


### PR DESCRIPTION
## ⭐️ Issue Number

- #107 

## 🚩 Summary

- 공동구매 판매자용 목록 조회 및 공동구매 상태 변경 API 연동

## 🛠️ Technical Concerns
1. 실시간 베스트 상세조회 API 연결
ProductRankingItem에 Link 추가하여 /groupbuys/{id}로 이동
2. 공구 관리 페이지 정렬
최신순 정렬 로직 추가 (updatedAt 기준)
3. 공구 등록 성공 후 리다이렉트
성공 모달창에서 확인 버튼 클릭 시 공구 관리 페이지로 이동
4. 공동구매 상품 목록 디자인 및 API 연동
5. 변경된 리워드 할인률 Dto 구조로 인한 데이터 연동 수정

## 🙂 To Reviewer
배송지 페이지에서 발생한 build 오류를 해결하기 위해 addresses가 undefined인 상태에서 .length 속성에 접근하는 문제를 해결했습니다.
구체적으로는:
Null 체크 추가: addresses?.length 형태로 optional chaining을 사용
기본값 설정: addresses || [] 형태로 빈 배열을 기본값으로 제공
타입 안전성 확보: TypeScript가 undefined 상태를 안전하게 처리할 수 있도록 개선
이렇게 하면 addresses 데이터가 아직 로딩되지 않았거나 API에서 null/undefined를 반환하는 경우에도 애플리케이션이 안전하게 동작합니다.

추가적으로 공구 목록 조회 부분 디자인이 어떤지 확인해주세요
<img width="867" height="750" alt="image" src="https://github.com/user-attachments/assets/b84227c3-3869-4e8d-97df-826a00708d09" />
<img width="1440" height="750" alt="image" src="https://github.com/user-attachments/assets/849eb203-c367-4386-8437-392616e43eef" />



## 📋 To Do


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 판매자를 위한 그룹 구매 관리 페이지가 추가되어, 인증된 판매자가 그룹 구매를 등록, 조회, 수정, 시작, 삭제할 수 있습니다.
  * 그룹 구매 목록에 페이지네이션, 상태별 집계, 카드형 목록, 상태 배지, 날짜 표시, 스크롤 상단 이동 기능이 제공됩니다.

* **개선 사항**
  * 상품 랭킹 아이템 전체가 클릭 가능한 링크로 변경되어, 클릭 시 해당 그룹 구매 상세로 이동합니다.
  * 그룹 구매 등록 성공 시, 성공 메시지 닫기와 함께 관리 페이지로 자동 이동됩니다.
  * 그룹 구매 관련 API 호출 및 훅의 에러 처리 로직이 개선되어, 사용자에게 보다 명확한 오류 메시지를 제공합니다.
  * 주소 목록 및 장바구니, 결제 관련 훅의 에러 처리 및 상태 관리가 강화되었습니다.
  * 그룹 구매 상태값 및 할인 단계 필드명이 일관되게 변경되어 데이터 구조가 명확해졌습니다.

* **버그 수정**
  * 할인 단계 정보의 필드명이 일관되게 변경되어, 할인 조건 및 계산이 정확하게 반영됩니다.
  * 주소 목록이 없을 때의 메시지 표시 조건이 개선되었습니다.

* **기타**
  * 그룹 구매 관련 타입 정의가 개선되어, 상태값 및 데이터 구조가 명확해졌습니다.
  * 그룹 구매 관련 서비스 함수가 추가되어, 상태 변경, 삭제, 목록 조회 기능이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->