### PR TITLE
공구 상세 페이지 장바구니/주문 API 연동

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import { metadata, viewport } from '@/lib/metadata';
 import { AuthProvider } from '@/components/auth/AuthProvider';
+import { Toaster } from 'sonner';
 
 export { metadata, viewport };
 
@@ -33,6 +34,7 @@ export default function RootLayout({
       </head>
       <body>
         <AuthProvider>{children}</AuthProvider>
+        <Toaster position="bottom-center" richColors />
       </body>
     </html>
   );

--- a/src/components/product/ActionButtons.tsx
+++ b/src/components/product/ActionButtons.tsx
@@ -10,6 +10,7 @@ interface ActionButtonsProps {
   className?: string;
   size?: 'default' | 'large';
   isBuyNowLoading?: boolean;
+  isAddToCartLoading?: boolean;
 }
 
 export const ActionButtons: FC<ActionButtonsProps> = ({
@@ -19,6 +20,7 @@ export const ActionButtons: FC<ActionButtonsProps> = ({
   className = '',
   size = 'default',
   isBuyNowLoading = false,
+  isAddToCartLoading = false,
 }) => {
   const isLarge = size === 'large';
   const buttonHeight = isLarge ? 'h-12 md:h-14' : 'h-[51px]';
@@ -38,8 +40,11 @@ export const ActionButtons: FC<ActionButtonsProps> = ({
         variant="outline"
         className={`flex flex-1 ${buttonHeight} items-center gap-2.5 rounded-lg border-primary-300 px-6 text-primary-300 transition hover:bg-primary-100 focus:ring-primary-300 active:bg-primary-100 md:px-10`}
         onClick={onAddToCart}
+        disabled={isAddToCartLoading}
       >
-        <span className={`${textSize} text-primary-300`}>장바구니</span>
+        <span className={`${textSize} text-primary-300`}>
+          {isAddToCartLoading ? '담는 중...' : '장바구니'}
+        </span>
       </Button>
       <Button
         className={`flex flex-1 ${buttonHeight} items-center gap-2.5 rounded-lg bg-primary-300 px-6 text-text-on transition hover:opacity-80 focus:ring-primary-300 active:opacity-90 md:px-10`}

--- a/src/components/product/ActionButtons.tsx
+++ b/src/components/product/ActionButtons.tsx
@@ -9,6 +9,7 @@ interface ActionButtonsProps {
   onBuyNow?: () => void;
   className?: string;
   size?: 'default' | 'large';
+  isBuyNowLoading?: boolean;
 }
 
 export const ActionButtons: FC<ActionButtonsProps> = ({
@@ -17,6 +18,7 @@ export const ActionButtons: FC<ActionButtonsProps> = ({
   onBuyNow,
   className = '',
   size = 'default',
+  isBuyNowLoading = false,
 }) => {
   const isLarge = size === 'large';
   const buttonHeight = isLarge ? 'h-12 md:h-14' : 'h-[51px]';
@@ -42,8 +44,11 @@ export const ActionButtons: FC<ActionButtonsProps> = ({
       <Button
         className={`flex flex-1 ${buttonHeight} items-center gap-2.5 rounded-lg bg-primary-300 px-6 text-text-on transition hover:opacity-80 focus:ring-primary-300 active:opacity-90 md:px-10`}
         onClick={onBuyNow}
+        disabled={isBuyNowLoading}
       >
-        <span className={`${textSize} text-text-on`}>바로구매</span>
+        <span className={`${textSize} text-text-on`}>
+          {isBuyNowLoading ? '주문 생성 중...' : '바로구매'}
+        </span>
       </Button>
     </div>
   );

--- a/src/components/product/OrderBox.tsx
+++ b/src/components/product/OrderBox.tsx
@@ -36,6 +36,18 @@ export const OrderBox = ({ product }: OrderBoxProps) => {
 
   const { handleShare, handleAddToCart, handleBuyNow } = useProductActions();
   const [isCreatingOrder, setIsCreatingOrder] = useState(false);
+  const [isAddingToCart, setIsAddingToCart] = useState(false);
+
+  const handleAddToCartClick = async () => {
+    if (selectedOptions.length > 0) {
+      setIsAddingToCart(true);
+      try {
+        await handleAddToCart(selectedOptions, product.options);
+      } finally {
+        setIsAddingToCart(false);
+      }
+    }
+  };
 
   const handleBuyNowClick = async () => {
     if (selectedOptions.length > 0) {
@@ -95,9 +107,10 @@ export const OrderBox = ({ product }: OrderBoxProps) => {
         {/* 액션 버튼 */}
         <ActionButtons
           onShare={handleShare}
-          onAddToCart={handleAddToCart}
+          onAddToCart={handleAddToCartClick}
           onBuyNow={handleBuyNowClick}
           isBuyNowLoading={isCreatingOrder}
+          isAddToCartLoading={isAddingToCart}
         />
       </Card>
     </>

--- a/src/components/product/OrderBox.tsx
+++ b/src/components/product/OrderBox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { Product } from '@/types/product';
 import { Card } from '@/components/ui/card';
 import { useProductOptions, useProductActions } from '@/hooks';
@@ -35,6 +35,18 @@ export const OrderBox = ({ product }: OrderBoxProps) => {
   } = useProductOptions(product);
 
   const { handleShare, handleAddToCart, handleBuyNow } = useProductActions();
+  const [isCreatingOrder, setIsCreatingOrder] = useState(false);
+
+  const handleBuyNowClick = async () => {
+    if (selectedOptions.length > 0) {
+      setIsCreatingOrder(true);
+      try {
+        await handleBuyNow(product.id, selectedOptions);
+      } finally {
+        setIsCreatingOrder(false);
+      }
+    }
+  };
 
   return (
     <>
@@ -84,7 +96,8 @@ export const OrderBox = ({ product }: OrderBoxProps) => {
         <ActionButtons
           onShare={handleShare}
           onAddToCart={handleAddToCart}
-          onBuyNow={handleBuyNow}
+          onBuyNow={handleBuyNowClick}
+          isBuyNowLoading={isCreatingOrder}
         />
       </Card>
     </>

--- a/src/components/product/OrderFloatingBar.tsx
+++ b/src/components/product/OrderFloatingBar.tsx
@@ -25,9 +25,15 @@ export function OrderFloatingBar({ product }: OrderFloatingBarProps) {
     handleChangeQuantity,
   } = useProductOptions(product);
 
-  const { handleShare, handlePurchase, handleBuyNow } = useProductActions();
+  const {
+    handleShare,
+    handlePurchase,
+    handleBuyNow,
+    handleAddToCart: addItemsToCart,
+  } = useProductActions();
   const router = useRouter();
   const [isCreatingOrder, setIsCreatingOrder] = useState(false);
+  const [isAddingToCart, setIsAddingToCart] = useState(false);
 
   // Drawer 열림/닫힘에 따라 body 스크롤 제어
   useEffect(() => {
@@ -65,9 +71,14 @@ export function OrderFloatingBar({ product }: OrderFloatingBarProps) {
     }
   };
 
-  const handleAddToCart = () => {
+  const handleAddToCartClick = async () => {
     if (isDrawerOpen && selectedOptions.length > 0) {
-      alert('장바구니에 성공적으로 담았습니다!');
+      setIsAddingToCart(true);
+      try {
+        await addItemsToCart(selectedOptions, product.options);
+      } finally {
+        setIsAddingToCart(false);
+      }
     } else {
       openDrawer();
     }
@@ -92,9 +103,12 @@ export function OrderFloatingBar({ product }: OrderFloatingBarProps) {
           <Button
             variant="outline"
             className={PRODUCT_STYLES.button.cart}
-            onClick={handleAddToCart}
+            onClick={handleAddToCartClick}
+            disabled={isAddingToCart}
           >
-            <span className="text-xs font-medium md:text-sm">장바구니</span>
+            <span className="text-xs font-medium md:text-sm">
+              {isAddingToCart ? '담는 중...' : '장바구니'}
+            </span>
           </Button>
           <Button
             className={PRODUCT_STYLES.button.buyNow}

--- a/src/components/product/OrderFloatingBar.tsx
+++ b/src/components/product/OrderFloatingBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { Product } from '@/types/product';
 import { Button } from '@/components/ui/button';
 import { Share, ChevronDown, ChevronUp } from 'lucide-react';
@@ -25,8 +25,9 @@ export function OrderFloatingBar({ product }: OrderFloatingBarProps) {
     handleChangeQuantity,
   } = useProductOptions(product);
 
-  const { handleShare, handlePurchase } = useProductActions();
+  const { handleShare, handlePurchase, handleBuyNow } = useProductActions();
   const router = useRouter();
+  const [isCreatingOrder, setIsCreatingOrder] = useState(false);
 
   // Drawer 열림/닫힘에 따라 body 스크롤 제어
   useEffect(() => {
@@ -50,10 +51,15 @@ export function OrderFloatingBar({ product }: OrderFloatingBarProps) {
     }
   };
 
-  const handleBuyNow = () => {
+  const handleBuyNowClick = async () => {
     if (isDrawerOpen && selectedOptions.length > 0) {
       closeDrawer();
-      alert('바로구매 하러 가볼게요!');
+      setIsCreatingOrder(true);
+      try {
+        await handleBuyNow(product.id, selectedOptions);
+      } finally {
+        setIsCreatingOrder(false);
+      }
     } else {
       openDrawer();
     }
@@ -90,8 +96,14 @@ export function OrderFloatingBar({ product }: OrderFloatingBarProps) {
           >
             <span className="text-xs font-medium md:text-sm">장바구니</span>
           </Button>
-          <Button className={PRODUCT_STYLES.button.buyNow} onClick={handleBuyNow}>
-            <span className="text-xs font-medium md:text-sm">바로구매</span>
+          <Button
+            className={PRODUCT_STYLES.button.buyNow}
+            onClick={handleBuyNowClick}
+            disabled={isCreatingOrder}
+          >
+            <span className="text-xs font-medium md:text-sm">
+              {isCreatingOrder ? '주문 생성 중...' : '바로구매'}
+            </span>
           </Button>
         </div>
       </div>

--- a/src/hooks/useProductActions.ts
+++ b/src/hooks/useProductActions.ts
@@ -1,4 +1,11 @@
+import { createGroupBuyOrder } from '@/services/groupbuyService';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import type { SelectedOption } from '@/types/product';
+
 export const useProductActions = () => {
+  const router = useRouter();
+
   const handleShare = () => {
     // 공유 로직
     // TODO: 실제 공유 기능 구현
@@ -9,9 +16,39 @@ export const useProductActions = () => {
     // TODO: 실제 장바구니 추가 기능 구현
   };
 
-  const handleBuyNow = () => {
-    // 바로구매 로직
-    // TODO: 실제 바로구매 기능 구현
+  // groupbuyId, selectedOptions를 인자로 받음
+  const handleBuyNow = async (groupbuyId: string | number, selectedOptions: SelectedOption[]) => {
+    if (!groupbuyId || !selectedOptions.length) {
+      toast.error('옵션을 선택해 주세요.');
+      return;
+    }
+    try {
+      const orderItems = selectedOptions.map((opt) => ({
+        groupbuyOptionId: Number(opt.value),
+        quantity: opt.quantity,
+      }));
+      const result = await createGroupBuyOrder({ groupbuyId, orderItems });
+      if (result.success) {
+        toast.success('주문이 생성되었습니다!');
+        // 주문 생성 전 현재 페이지 저장 (만료 시 돌아갈 페이지)
+        sessionStorage.setItem('orderReferrer', window.location.pathname);
+        // 주문 데이터에 생성 시간 추가
+        const orderDataWithTimestamp = {
+          ...result.data,
+          createdAt: Date.now(),
+        };
+        // 주문 데이터를 sessionStorage에 저장
+        sessionStorage.setItem('orderData', JSON.stringify(orderDataWithTimestamp));
+        // 주문 생성 성공 시 order 페이지로 이동
+        router.push(`/order/${result.data.orderId}`);
+      } else {
+        toast.error(result.message || '주문 생성에 실패했습니다.');
+      }
+    } catch (error: any) {
+      toast.error(
+        error?.response?.data?.message || error.message || '주문 생성 중 오류가 발생했습니다.',
+      );
+    }
   };
 
   const handlePurchase = () => {

--- a/src/services/cartService.ts
+++ b/src/services/cartService.ts
@@ -62,3 +62,13 @@ export async function createOrderFromCart(
   });
   return response.data;
 }
+
+/**
+ * 여러 옵션을 한 번에 장바구니에 담기
+ * @param items - [{ groupbuyOptionId, quantity }, ...]
+ * @returns 추가된 장바구니 아이템 정보
+ */
+export async function addItemsToCart(items: Array<{ groupbuyOptionId: number; quantity: number }>) {
+  const response = await api.post('/cart/items', items);
+  return response.data;
+}

--- a/src/services/cartService.ts
+++ b/src/services/cartService.ts
@@ -7,6 +7,8 @@ import {
   ApiDeleteCartItemResponse,
   ApiCreateOrderRequest,
   ApiCreateOrderResponse,
+  ApiAddItemsToCartRequest,
+  ApiAddItemsToCartResponse,
 } from '@/types/api';
 
 /**
@@ -68,7 +70,12 @@ export async function createOrderFromCart(
  * @param items - [{ groupbuyOptionId, quantity }, ...]
  * @returns 추가된 장바구니 아이템 정보
  */
-export async function addItemsToCart(items: Array<{ groupbuyOptionId: number; quantity: number }>) {
-  const response = await api.post('/cart/items', items);
+export async function addItemsToCart(
+  items: ApiAddItemsToCartRequest,
+): Promise<ApiResponseFormat<ApiAddItemsToCartResponse>> {
+  const response = await api.post<ApiResponseFormat<ApiAddItemsToCartResponse>>(
+    '/cart/items',
+    items,
+  );
   return response.data;
 }

--- a/src/services/groupbuyService.ts
+++ b/src/services/groupbuyService.ts
@@ -9,6 +9,7 @@ import type {
   GroupBuyDetailResponse,
   GroupBuyDetail,
 } from '@/types/groupbuy';
+import type { ApiResponseFormat, ApiCreateOrderResponse } from '@/types/api';
 import { Suspense } from 'react';
 
 // 인증이 필요하지 않은 API 호출을 위한 별도 인스턴스
@@ -82,16 +83,19 @@ export async function getGroupBuyDetail(groupBuyId: number): Promise<GroupBuyDet
   return response.data;
 }
 
-// 공구 주문 생성 API
-export async function createGroupBuyOrder({
-  groupbuyId,
-  orderItems,
-}: {
-  groupbuyId: number | string;
-  orderItems: Array<{ groupbuyOptionId: number; quantity: number }>;
-}) {
-  const res = await api.post(`/groupbuys/${groupbuyId}/orders`, {
-    orderItems,
-  });
+/**
+ * 공동구매 주문 생성
+ * @param groupbuyId - 공동구매 ID
+ * @param orderItems - 주문할 아이템 목록
+ * @returns 생성된 주문 정보
+ */
+export async function createGroupBuyOrder(
+  groupbuyId: number,
+  orderItems: Array<{ groupbuyOptionId: number; quantity: number }>,
+): Promise<ApiResponseFormat<ApiCreateOrderResponse>> {
+  const res = await api.post<ApiResponseFormat<ApiCreateOrderResponse>>(
+    `/groupbuys/${groupbuyId}/orders`,
+    { orderItems },
+  );
   return res.data;
 }

--- a/src/services/groupbuyService.ts
+++ b/src/services/groupbuyService.ts
@@ -76,19 +76,12 @@ export async function createGroupBuy({
   return res.data;
 }
 
-<<<<<<< Updated upstream
 // 공동구매 상세 조회 API (인증 불필요)
 export async function getGroupBuyDetail(groupBuyId: number): Promise<GroupBuyDetailResponse> {
-  console.log('Requesting groupbuy detail for ID:', groupBuyId);
-  console.log(
-    'Full URL:',
-    `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api'}/groupbuys/${groupBuyId}`,
-  );
-
   const response = await publicApi.get<GroupBuyDetailResponse>(`/groupbuys/${groupBuyId}`);
-  console.log('Raw API Response:', response);
   return response.data;
-=======
+}
+
 // 공구 주문 생성 API
 export async function createGroupBuyOrder({
   groupbuyId,
@@ -101,5 +94,4 @@ export async function createGroupBuyOrder({
     orderItems,
   });
   return res.data;
->>>>>>> Stashed changes
 }

--- a/src/services/groupbuyService.ts
+++ b/src/services/groupbuyService.ts
@@ -76,6 +76,7 @@ export async function createGroupBuy({
   return res.data;
 }
 
+<<<<<<< Updated upstream
 // 공동구매 상세 조회 API (인증 불필요)
 export async function getGroupBuyDetail(groupBuyId: number): Promise<GroupBuyDetailResponse> {
   console.log('Requesting groupbuy detail for ID:', groupBuyId);
@@ -87,4 +88,18 @@ export async function getGroupBuyDetail(groupBuyId: number): Promise<GroupBuyDet
   const response = await publicApi.get<GroupBuyDetailResponse>(`/groupbuys/${groupBuyId}`);
   console.log('Raw API Response:', response);
   return response.data;
+=======
+// 공구 주문 생성 API
+export async function createGroupBuyOrder({
+  groupbuyId,
+  orderItems,
+}: {
+  groupbuyId: number | string;
+  orderItems: Array<{ groupbuyOptionId: number; quantity: number }>;
+}) {
+  const res = await api.post(`/groupbuys/${groupbuyId}/orders`, {
+    orderItems,
+  });
+  return res.data;
+>>>>>>> Stashed changes
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -117,3 +117,16 @@ export interface ShippingAddress {
 export interface ShippingAddressResponse {
   addresses: ShippingAddress[];
 }
+
+// 여러 옵션 동시 장바구니 담기 요청/응답 타입
+export type ApiAddItemsToCartRequest = Array<{
+  groupbuyOptionId: number;
+  quantity: number;
+}>;
+
+export interface ApiAddItemsToCartResponse {
+  cartItems: Array<{
+    cartItemId: number;
+    quantity: number;
+  }>;
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #111

## 🚩 Summary
- 공동구매 상세 페이지에서 **공구 주문 생성** 및 **장바구니 담기 기능을 API와 연동**하고,
UX 흐름을 장바구니와 동일하게 구성하였습니다.
- 또한, `handleBuyNow` 시 `sessionStorage`를 활용한 주문 상태 저장,
로딩 상태 처리, 에러 메시지 동적 치환 등 UX 개선 작업도 함께 수행하였습니다.

## 🛠️ Technical Concerns
### 1. 공구 주문 생성 플로우 구현 (`POST /groupbuys/{groupbuyId}/orders`)
- 사용자가 **'바로구매' 버튼 클릭 시** `selectedOptions` 기반으로 API 호출
- 주문 생성 성공 시:
  - 응답 데이터(`orderId`, `orderItems`, `totalAmount`, 등)를 `sessionStorage`에 저장
  - `/order/[orderId]`로 이동하여 **결제 플로우 진입**
  - 현재 페이지 경로를 `orderReferrer`로 저장하여 이후 복귀 시 활용
- 실패 시: 토스트 메시지로 사용자에게 안내
- 로딩 중에는 버튼을 비활성화하고 `"주문 생성 중..."` 문구로 상태 표시

### 2. 장바구니 담기 플로우 구현 (`POST /cart/items`)
- 사용자가 **'장바구니' 버튼 클릭 시** `selectedOptions` 기반으로 API 요청
- 성공/실패 여부에 따라 `toast` 메시지 표시
- 동일하게 `"담는 중..."` 로딩 문구와 `disabled` 처리 반영

## 🙂 To Reviewer
- 주문 생성 시점에 `sessionStorage`에 저장하는 방식의 적정성 검토 요청
- 장바구니/주문 흐름에서 공통 UX로 통일된 구조가 유지되는지 확인 부탁드립니다.

## 📋 To Do
- [ ] 환불 API 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * "장바구니" 및 "바로구매" 버튼에 비동기 처리 및 로딩 상태 표시가 추가되어, 동작 중 버튼이 비활성화되고 진행 상황을 알리는 메시지가 표시됩니다.
  * 여러 상품 옵션을 한 번에 장바구니에 추가할 수 있습니다.
  * 그룹구매 주문 생성 기능이 추가되었습니다.

* **버그 수정**
  * 불필요한 콘솔 로그가 제거되어 사용자 경험이 개선되었습니다.

* **UI 개선**
  * 알림(Toast) 컴포넌트가 하단 중앙에 표시되어, 주요 작업 결과를 즉시 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->